### PR TITLE
Add post-upgrade helm hook for `default-classifier`

### DIFF
--- a/charts/projectsveltos/templates/default-classifier.yaml
+++ b/charts/projectsveltos/templates/default-classifier.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
   {{- include "projectsveltos.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": "post-install"
+    "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "5"
     "helm.sh/hook-delete-policy": "hook-failed"
 spec:


### PR DESCRIPTION
## Description
This is a simple change to add a post upgrade hook to the default classifier as well. Sometimes while deploying charts through Flux's HelmRelease, it performs the upgrade action if it finds existing release in storage:
```sh
2024-09-05T18:02:42.835Z info HelmRelease/hmc.hmc-system - release not managed by controller: found existing release in storage 
2024-09-05T18:02:42.843Z info HelmRelease/hmc.hmc-system - running 'upgrade' action with timeout of 5m0s 
```
So without the `post-upgrade` hook, the `default-classifier` is not installed when installing projectsveltos Helm chart.