### PR TITLE
(feat) do not start conversion webhook by default

### DIFF
--- a/charts/projectsveltos/Chart.yaml
+++ b/charts/projectsveltos/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.44.1
+version: 0.44.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/projectsveltos/templates/deployment.yaml
+++ b/charts/projectsveltos/templates/deployment.yaml
@@ -597,6 +597,7 @@ metadata:
   name: register-mgmt-cluster
   labels:
   {{- include "projectsveltos.labels" . | nindent 4 }}
+{{ if .Values.webhook.conversion }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -668,4 +669,4 @@ spec:
         secret:
           defaultMode: 420
           secretName: webhook-server-cert
-
+{{ end }}

--- a/charts/projectsveltos/templates/project-selfsigned-issuer.yaml
+++ b/charts/projectsveltos/templates/project-selfsigned-issuer.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.webhook.conversion }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -6,3 +7,4 @@ metadata:
   {{- include "projectsveltos.labels" . | nindent 4 }}
 spec:
   selfSigned: {}
+{{ end }}

--- a/charts/projectsveltos/templates/projectsveltos-mutating-webhook-configuration.yaml
+++ b/charts/projectsveltos/templates/projectsveltos-mutating-webhook-configuration.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.webhook.conversion }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -18,3 +19,4 @@ webhooks:
   failurePolicy: Fail
   name: mclusterprofile.projectsveltos.io
   sideEffects: None
+{{ end }}

--- a/charts/projectsveltos/templates/projectsveltos-serving-cert.yaml
+++ b/charts/projectsveltos/templates/projectsveltos-serving-cert.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.webhook.conversion }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -12,3 +13,4 @@ spec:
     kind: Issuer
     name: 'project-selfsigned-issuer'
   secretName: webhook-server-cert
+{{ end }}

--- a/charts/projectsveltos/templates/webhook-service.yaml
+++ b/charts/projectsveltos/templates/webhook-service.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.webhook.conversion }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -11,3 +12,4 @@ spec:
   {{- include "projectsveltos.selectorLabels" . | nindent 4 }}
   ports:
 	{{- .Values.webhookService.ports | toYaml | nindent 2 -}}
+{{ end }}

--- a/charts/projectsveltos/values.yaml
+++ b/charts/projectsveltos/values.yaml
@@ -251,3 +251,5 @@ webhookService:
     protocol: TCP
     targetPort: 9443
   type: ClusterIP
+webhook:
+  conversion: false


### PR DESCRIPTION
Conversion webhook was added to handle systems still using v1alpha1.
Conversion webhook requires cert-manager to be present in the management cluster.

Given v1beta1 were introduced first in v0.33.0, assume everyone is now on v1beta1. So disable by default the conversion webhook.