### PR TITLE
Add digest

### DIFF
--- a/charts/projectsveltos/Chart.yaml
+++ b/charts/projectsveltos/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.46.1
+version: 0.46.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/projectsveltos/templates/deployment.yaml
+++ b/charts/projectsveltos/templates/deployment.yaml
@@ -58,8 +58,7 @@ spec:
         {{- with .Values.addonController.controller.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        image: {{ .Values.addonController.controller.image.repository }}:{{ .Values.addonController.controller.image.tag
-          | default .Chart.AppVersion }}
+        image: {{ .Values.addonController.controller.image.repository }}{{- if .Values.global.useDigest }}@{{ .Values.addonController.controller.image.digest }}{{- else }}:{{ .Values.addonController.controller.image.tag | default .Chart.AppVersion }}{{- end }}
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -141,8 +140,7 @@ spec:
         {{- with .Values.accessManager.manager.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        image: {{ .Values.accessManager.manager.image.repository }}:{{ .Values.accessManager.manager.image.tag
-          | default .Chart.AppVersion }}
+        image: {{ .Values.accessManager.manager.image.repository }}{{- if .Values.global.useDigest }}@{{ .Values.accessManager.manager.image.digest }}{{- else }}:{{ .Values.accessManager.manager.image.tag | default .Chart.AppVersion }}{{- end }}
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -217,8 +215,7 @@ spec:
         {{- with .Values.scManager.manager.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        image: {{ .Values.scManager.manager.image.repository }}:{{ .Values.scManager.manager.image.tag
-          | default .Chart.AppVersion }}
+        image: {{ .Values.scManager.manager.image.repository }}{{- if .Values.global.useDigest }}@{{ .Values.scManager.manager.image.digest }}{{- else }}:{{ .Values.scManager.manager.image.tag | default .Chart.AppVersion }}{{- end }}
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -293,8 +290,7 @@ spec:
         {{- with .Values.hcManager.manager.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        image: {{ .Values.hcManager.manager.image.repository }}:{{ .Values.hcManager.manager.image.tag
-          | default .Chart.AppVersion }}
+        image: {{ .Values.hcManager.manager.image.repository }}{{- if .Values.global.useDigest }}@{{ .Values.hcManager.manager.image.digest }}{{- else }}:{{ .Values.hcManager.manager.image.tag | default .Chart.AppVersion }}{{- end }}
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -369,8 +365,7 @@ spec:
         {{- with .Values.eventManager.manager.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        image: {{ .Values.eventManager.manager.image.repository }}:{{ .Values.eventManager.manager.image.tag
-          | default .Chart.AppVersion }}
+        image: {{ .Values.eventManager.manager.image.repository }}{{- if .Values.global.useDigest }}@{{ .Values.eventManager.manager.image.digest }}{{- else }}:{{ .Values.eventManager.manager.image.tag | default .Chart.AppVersion }}{{- end }}
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -450,8 +445,7 @@ spec:
         {{- with .Values.classifierManager.manager.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        image: {{ .Values.classifierManager.manager.image.repository }}:{{ .Values.classifierManager.manager.image.tag
-          | default .Chart.AppVersion }}
+        image: {{ .Values.classifierManager.manager.image.repository }}{{- if .Values.global.useDigest }}@{{ .Values.classifierManager.manager.image.digest }}{{- else }}:{{ .Values.classifierManager.manager.image.tag | default .Chart.AppVersion }}{{- end }}
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -531,8 +525,7 @@ spec:
         {{- with .Values.shardController.manager.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        image: {{ .Values.shardController.manager.image.repository }}:{{ .Values.shardController.manager.image.tag
-          | default .Chart.AppVersion }}
+        image: {{ .Values.shardController.manager.image.repository }}{{- if .Values.global.useDigest }}@{{ .Values.shardController.manager.image.digest }}{{- else }}:{{ .Values.shardController.manager.image.tag | default .Chart.AppVersion }}{{- end }}
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -599,8 +592,7 @@ spec:
         {{- with .Values.shardController.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        image: {{ .Values.conversionWebhook.sveltosWebhook.image.repository }}:{{ .Values.conversionWebhook.sveltosWebhook.image.tag
-          | default .Chart.AppVersion }}
+        image: {{ .Values.conversionWebhook.sveltosWebhook.image.repository }}{{- if .Values.global.useDigest }}@{{ .Values.conversionWebhook.sveltosWebhook.image.digest }}{{- else }}:{{ .Values.conversionWebhook.sveltosWebhook.image.tag | default .Chart.AppVersion }}{{- end }}
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/charts/projectsveltos/values.yaml
+++ b/charts/projectsveltos/values.yaml
@@ -1,4 +1,5 @@
-global:  
+global:
+  useDigest: false
   imagePullSecrets: []
  #   - name: my-registry-secret
 accessManager:
@@ -15,6 +16,7 @@ accessManager:
     image:
       repository: docker.io/projectsveltos/access-manager
       tag: v0.46.1
+      digest: sha256:c7794284849869f58c8bbb4df0effa89b7a7ede4944ee13b59dcd1693f19b168
     resources:
       limits:
         cpu: 500m
@@ -55,6 +57,7 @@ addonController:
     image:
       repository: docker.io/projectsveltos/addon-controller
       tag: v0.46.1
+      digest: sha256:ddaeb145b380227c9d71124c8240413660a8d18ce6aafb33acaf30459574947f 
     resources:
       requests:
         memory: 256Mi
@@ -96,6 +99,7 @@ classifierManager:
     image:
       repository: docker.io/projectsveltos/classifier
       tag: v0.46.1
+      digest: sha256:15cfc305c1aa8b85d0301130216e4e65a1eefc24ea7fc94c8d8568aaabb8c16e
     resources:
       limits:
         cpu: 500m
@@ -123,6 +127,7 @@ conversionWebhook:
     image:
       repository: docker.io/projectsveltos/webhook-conversion
       tag: v0.46.1
+      digest: sha256:37950f0a06661558ede2d58216d232d3dee5361be36ac29bde13cb1c34089cb6
     resources:
       limits:
         cpu: 500m
@@ -152,6 +157,7 @@ eventManager:
     image:
       repository: docker.io/projectsveltos/event-manager
       tag: v0.46.1
+      digest: sha256:e78ad8c5c20edf2f5ae68851c8b5ceac7ca0452bd98ae182f5e210e822b49fb3
     resources:
       limits:
         cpu: 500m
@@ -181,7 +187,8 @@ hcManager:
         - ALL
     image:
       repository: docker.io/projectsveltos/healthcheck-manager
-      tag: v0.46.1
+      tag: v0.46.1 
+      digest: sha256:9a6442be8d7be2de4ef0b0e7f3d9a050b4516e8bf12d10c6491115349312ade1
     resources:
       limits:
         cpu: 500m
@@ -215,6 +222,7 @@ registerMgmtClusterJob:
     image:
       repository: docker.io/projectsveltos/register-mgmt-cluster
       tag: v0.46.1
+      digest: sha256:a426b6915389bc5ed137e03c5bad55f24727fa22ad897cd1fec81fbd5b36d1e7 
     imagePullPolicy: IfNotPresent
     resources:
       requests:
@@ -234,6 +242,7 @@ scManager:
     image:
       repository: docker.io/projectsveltos/sveltoscluster-manager
       tag: v0.46.1
+      digest: sha256:1cb2b903628a90aae74a7fecfd4a17fee21c60674160e8917dc875d24d4b0786 
     resources:
       limits:
         cpu: 500m
@@ -274,6 +283,7 @@ shardController:
     image:
       repository: docker.io/projectsveltos/shard-controller
       tag: v0.46.1
+      digest: sha256:9206fbf14bec49414c8bc3a1aa92ab9bc85528a745b94fb1b8451df2665da368 
     resources:
       limits:
         cpu: 500m

--- a/scripts/get_digest.sh
+++ b/scripts/get_digest.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Function to get the image digest
+get_image_digest() {
+  base_name="$1"  # e.g., addon-controller
+  tag="$2"
+
+  # Check if both arguments are provided
+  if [ -z "$base_name" ] || [ -z "$tag" ]; then
+    echo "Usage: $0 <base_name> <tag>"
+    return 1
+  fi
+
+  image_name="docker.io/projectsveltos/$base_name:$tag"
+
+  digest=$(skopeo inspect --format '{{.Digest}}' "docker://$image_name" --override-os="linux" --override-arch="amd64" --override-variant="v8" 2>/dev/null)
+
+  if [ -z "$digest" ]; then
+    echo "Error: Could not retrieve digest for $image_name"
+    return 1
+  fi
+
+  echo "$digest"
+  return 0
+}
+
+# Main script
+if [ $# -ne 1 ]; then  # Check for exactly 1 argument, the tag
+  echo "Usage: $0 <tag>"
+  exit 1
+fi
+
+
+tag="$1"
+# Array of base names
+declare -a base_names=(
+  "addon-controller"
+  "event-manager"
+  "webhook-conversion"
+  "register-mgmt-cluster"
+  "shard-controller"
+  "healthcheck-manager"
+  "sveltoscluster-manager"
+  "access-manager"
+  "classifier"
+)
+
+# Loop through the base names
+for base_name in "${base_names[@]}"; do
+  digest=$(get_image_digest "$base_name" "$tag")
+
+  if [ $? -ne 0 ]; then
+    echo "Error getting digest for $base_name."
+    exit 1
+  fi
+
+  echo "$base_name: $digest"
+done
+


### PR DESCRIPTION
If global.useDigest is set, digest is used instead of tag

The script get_digest.sh can be used to fetch digest for each image for a given tag.
For instance

```
./get_digest.sh v0.46.1
addon-controller: sha256:ddaeb145b380227c9d71124c8240413660a8d18ce6aafb33acaf30459574947f 
event-manager: sha256:e78ad8c5c20edf2f5ae68851c8b5ceac7ca0452bd98ae182f5e210e822b49fb3
webhook-conversion: sha256:37950f0a06661558ede2d58216d232d3dee5361be36ac29bde13cb1c34089cb6 register-mgmt-cluster: sha256:a426b6915389bc5ed137e03c5bad55f24727fa22ad897cd1fec81fbd5b36d1e7 
shard-controller: sha256:9206fbf14bec49414c8bc3a1aa92ab9bc85528a745b94fb1b8451df2665da368 
healthcheck-manager: sha256:9a6442be8d7be2de4ef0b0e7f3d9a050b4516e8bf12d10c6491115349312ade1
sveltoscluster-manager: sha256:1cb2b903628a90aae74a7fecfd4a17fee21c60674160e8917dc875d24d4b0786
access-manager: sha256:c7794284849869f58c8bbb4df0effa89b7a7ede4944ee13b59dcd1693f19b168 
classifier: sha256:15cfc305c1aa8b85d0301130216e4e65a1eefc24ea7fc94c8d8568aaabb8c16e
```

Fixes [474](https://github.com/projectsveltos/sveltos/issues/474)