### PR TITLE
Add ConfigMaps for agent and drift detection patches

### DIFF
--- a/charts/projectsveltos/templates/configmap.yaml
+++ b/charts/projectsveltos/templates/configmap.yaml
@@ -1,0 +1,28 @@
+{{- if ne (len .Values.addonController.driftDetectionManagerPatchConfigMap.data) 0 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.addonController.driftDetectionManagerPatchConfigMap.name }}
+  labels:
+    {{- include "projectsveltos.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.addonController.driftDetectionManagerPatchConfigMap.data }}
+  {{ $key }}: |-
+    {{- $value | toString | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- if ne (len .Values.classifierManager.agentPatchConfigMap.data) 0 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.classifierManager.agentPatchConfigMap.name }}
+  labels:
+    {{- include "projectsveltos.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.classifierManager.agentPatchConfigMap.data }}
+  {{ $key }}: |-
+    {{- $value | toString | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/projectsveltos/templates/deployment.yaml
+++ b/charts/projectsveltos/templates/deployment.yaml
@@ -32,11 +32,14 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-{{ if .Values.agent.managementCluster }}      
-      - args: {{- toYaml .Values.addonController.controller.argsAgentMgmtCluster | nindent 8 }}
+{{- if .Values.agent.managementCluster }}      
+      - args: {{- toYaml .Values.addonController.controller.argsAgentMgmtCluster | nindent 8 -}}
 {{ else }}
-      - args: {{- toYaml .Values.addonController.controller.args | nindent 8 }}
-{{ end }}
+      - args: {{- toYaml .Values.addonController.controller.args | nindent 8 -}}
+{{- end }}
+{{- if ne (len .Values.addonController.driftDetectionManagerPatchConfigMap.data) 0 }}
+        - --drift-detection-config={{ .Values.addonController.driftDetectionManagerPatchConfigMap.name }}
+{{- end }}
 {{- if .Values.telemetry.disabled }}
     {{"-  --disable-telemetry=true" | nindent 8 }}
 {{- end }}
@@ -437,11 +440,14 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-{{ if .Values.agent.managementCluster }}      
-      - args: {{- toYaml .Values.classifierManager.manager.argsAgentMgmtCluster | nindent 8 }}
+{{- if .Values.agent.managementCluster }}      
+      - args: {{- toYaml .Values.classifierManager.manager.argsAgentMgmtCluster | nindent 8 -}}
 {{ else }}
-      - args: {{- toYaml .Values.classifierManager.manager.args | nindent 8 }}
-{{ end }}
+      - args: {{- toYaml .Values.classifierManager.manager.args | nindent 8 -}}
+{{- end }}
+{{- if ne (len .Values.classifierManager.agentPatchConfigMap.data) 0 }}
+        - --sveltos-agent-config={{ .Values.classifierManager.agentPatchConfigMap.name }}
+{{- end }}
         command:
         - /manager
         env:
@@ -518,11 +524,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-{{ if .Values.agent.managementCluster }}
+{{- if .Values.agent.managementCluster }}
       - args: {{- toYaml .Values.shardController.manager.argsAgentMgmtCluster | nindent 8 }}
-{{ else }}
+{{- else -}}
       - args: {{- toYaml .Values.shardController.manager.args | nindent 8 }}
-{{ end }}
+{{- end }}
         command:
         - /manager
         env:

--- a/charts/projectsveltos/values.yaml
+++ b/charts/projectsveltos/values.yaml
@@ -44,7 +44,6 @@ addonController:
     - --shard-key=
     - --v=5
     - --version=v0.46.1
-    extraEnv: []
     containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -59,6 +58,9 @@ addonController:
       requests:
         memory: 256Mi
     extraEnv: []
+  driftDetectionManagerPatchConfigMap:
+    name: drift-detection-config
+    data: {}
   podSecurityContext:
     runAsNonRoot: true
   ports:
@@ -73,6 +75,9 @@ addonController:
     annotations: {}
   type: ClusterIP
 classifierManager:
+  agentPatchConfigMap:
+    name: sveltos-agent-config
+    data: {}
   manager:
     args:
     - --diagnostics-address=:8443
@@ -111,6 +116,7 @@ classifierManager:
   serviceAccount:
     annotations: {}
 conversionWebhook:
+  nodeSelector: {}
   podSecurityContext:
     runAsNonRoot: true
   replicas: 1
@@ -130,8 +136,6 @@ conversionWebhook:
       requests:
         cpu: 10m
         memory: 64Mi
-  nodeSelector: {}
-  replicas: 1
   tolerations: []
 driftDetectionManager:
   serviceAccount:


### PR DESCRIPTION
## Description

It's possible to patch the agent and the drift-detection deployments with custom `ConfigMaps` as described [here](https://projectsveltos.github.io/sveltos/getting_started/install/air_gapped_installation/). This was not possible with the helm chart directly but in an additional step.

This PR adds the option to pass in the name and the data of the `ConfigMaps` for both deployments so that the UX improves.

### Additional information

I also took chance to remove some duplicate values in the `values.yaml` and fix some formatting (mainly removing obsolete blank lines).

## Documentation

As soon as this gets accepted, I'd also update the documentation on how to use this in order to adjust the drift-detection and agent deployments.