### PR TITLE
Change registry to avoid docker.io rate limits

### DIFF
--- a/charts/dashboard/README.md
+++ b/charts/dashboard/README.md
@@ -10,7 +10,7 @@ A Helm chart for Sveltos dashboard
 |-----|------|---------|-------------|
 | global.useDigest | bool | `false` |  |
 | global.imagePullSecrets | list | `[]` |  |
-| dashboard.dashboard.image.repository | string | `"docker.io/projectsveltos/dashboard"` |  |
+| dashboard.dashboard.image.repository | string | `"mirror.gcr.io/projectsveltos/dashboard"` |  |
 | dashboard.dashboard.image.tag | string | `"v0.49.0"` |  |
 | dashboard.dashboard.image.digest | string | `"sha256:7bdc2bbf54097f62d66a392643b632f265292672c30603cf88d57966b8413e6f"` |  |
 | dashboard.ports[0].port | int | `80` |  |

--- a/charts/dashboard/values.yaml
+++ b/charts/dashboard/values.yaml
@@ -4,7 +4,7 @@ global:
 dashboard:
   dashboard:
     image:
-      repository: docker.io/projectsveltos/dashboard
+      repository: mirror.gcr.io/projectsveltos/dashboard
       tag: v0.49.0
       digest: sha256:7bdc2bbf54097f62d66a392643b632f265292672c30603cf88d57966b8413e6f
   ports:

--- a/charts/projectsveltos/README.md
+++ b/charts/projectsveltos/README.md
@@ -17,7 +17,7 @@ Projectsveltos helm chart for Kubernetes
 | accessManager.manager.extraEnv | list | `[]` |  |
 | accessManager.manager.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | accessManager.manager.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
-| accessManager.manager.image.repository | string | `"docker.io/projectsveltos/access-manager"` |  |
+| accessManager.manager.image.repository | string | `"mirror.gcr.io/projectsveltos/access-manager"` |  |
 | accessManager.manager.image.tag | string | `"v0.49.0"` |  |
 | accessManager.manager.image.digest | string | `"sha256:1e96dbf30896ab2eb033e148fcaf01adb9d0ccefff5de1cb947c73939d5e7cf9"` |  |
 | accessManager.manager.resources.limits.cpu | string | `"500m"` |  |
@@ -46,7 +46,7 @@ Projectsveltos helm chart for Kubernetes
 | addonController.controller.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | addonController.controller.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | addonController.controller.containerSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
-| addonController.controller.image.repository | string | `"docker.io/projectsveltos/addon-controller"` |  |
+| addonController.controller.image.repository | string | `"mirror.gcr.io/projectsveltos/addon-controller"` |  |
 | addonController.controller.image.tag | string | `"v0.49.0"` |  |
 | addonController.controller.image.digest | string | `"sha256:1b65773d03eb864dd08a6f7c53b4f96333c49b420b3dea8446e5ecfb4878c7ca"` |  |
 | addonController.controller.resources.requests.memory | string | `"512Mi"` |  |
@@ -80,7 +80,7 @@ Projectsveltos helm chart for Kubernetes
 | classifierManager.manager.extraEnv | list | `[]` |  |
 | classifierManager.manager.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | classifierManager.manager.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
-| classifierManager.manager.image.repository | string | `"docker.io/projectsveltos/classifier"` |  |
+| classifierManager.manager.image.repository | string | `"mirror.gcr.io/projectsveltos/classifier"` |  |
 | classifierManager.manager.image.tag | string | `"v0.49.0"` |  |
 | classifierManager.manager.image.digest | string | `"sha256:1009c617a5b33965ff97ec830b427b836e5a1ea13dd9df91228d12ed818ab61c"` |  |
 | classifierManager.manager.resources.limits.cpu | string | `"500m"` |  |
@@ -101,7 +101,7 @@ Projectsveltos helm chart for Kubernetes
 | eventManager.manager.extraEnv | list | `[]` |  |
 | eventManager.manager.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | eventManager.manager.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
-| eventManager.manager.image.repository | string | `"docker.io/projectsveltos/event-manager"` |  |
+| eventManager.manager.image.repository | string | `"mirror.gcr.io/projectsveltos/event-manager"` |  |
 | eventManager.manager.image.tag | string | `"v0.49.0"` |  |
 | eventManager.manager.image.digest | string | `"sha256:2a04eb744d78b6b1c15ecc90613558c4b553ced12d27ea1d2b829611f9d04939"` |  |
 | eventManager.manager.resources.limits.cpu | string | `"500m"` |  |
@@ -121,7 +121,7 @@ Projectsveltos helm chart for Kubernetes
 | hcManager.manager.extraEnv | list | `[]` |  |
 | hcManager.manager.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | hcManager.manager.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
-| hcManager.manager.image.repository | string | `"docker.io/projectsveltos/healthcheck-manager"` |  |
+| hcManager.manager.image.repository | string | `"mirror.gcr.io/projectsveltos/healthcheck-manager"` |  |
 | hcManager.manager.image.tag | string | `"v0.49.0"` |  |
 | hcManager.manager.image.digest | string | `"sha256:94dce3b79405dac357430de39cfb1f596b4f148afb4d6f5dfcf2b6d4905931f6"` |  |
 | hcManager.manager.resources.limits.cpu | string | `"500m"` |  |
@@ -142,7 +142,7 @@ Projectsveltos helm chart for Kubernetes
 | registerMgmtClusterJob.registerMgmtCluster.extraEnv | list | `[]` |  |
 | registerMgmtClusterJob.registerMgmtCluster.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | registerMgmtClusterJob.registerMgmtCluster.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
-| registerMgmtClusterJob.registerMgmtCluster.image.repository | string | `"docker.io/projectsveltos/register-mgmt-cluster"` |  |
+| registerMgmtClusterJob.registerMgmtCluster.image.repository | string | `"mirror.gcr.io/projectsveltos/register-mgmt-cluster"` |  |
 | registerMgmtClusterJob.registerMgmtCluster.image.tag | string | `"v0.49.0"` |  |
 | registerMgmtClusterJob.registerMgmtCluster.image.digest | string | `"sha256:80056d75f1e4d63f40fa6c461e05e9361fb8dad2627e52bb2ac43d94ffdf332c"` |  |
 | registerMgmtClusterJob.registerMgmtCluster.imagePullPolicy | string | `"IfNotPresent"` |  |
@@ -154,7 +154,7 @@ Projectsveltos helm chart for Kubernetes
 | scManager.manager.extraEnv | list | `[]` |  |
 | scManager.manager.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | scManager.manager.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
-| scManager.manager.image.repository | string | `"docker.io/projectsveltos/sveltoscluster-manager"` |  |
+| scManager.manager.image.repository | string | `"mirror.gcr.io/projectsveltos/sveltoscluster-manager"` |  |
 | scManager.manager.image.tag | string | `"v0.49.0"` |  |
 | scManager.manager.image.digest | string | `"sha256:e486834d42ec6b98fa4772936d46c73edd54b954718757f0554b4332cb6993b4"` |  |
 | scManager.manager.resources.limits.cpu | string | `"500m"` |  |
@@ -184,7 +184,7 @@ Projectsveltos helm chart for Kubernetes
 | shardController.manager.extraEnv | list | `[]` |  |
 | shardController.manager.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | shardController.manager.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
-| shardController.manager.image.repository | string | `"docker.io/projectsveltos/shard-controller"` |  |
+| shardController.manager.image.repository | string | `"mirror.gcr.io/projectsveltos/shard-controller"` |  |
 | shardController.manager.image.tag | string | `"v0.49.0"` |  |
 | shardController.manager.image.digest | string | `"sha256:08797d8e786c51794dad98141f42a796d827bfae2e7db6d97fb7e9aa4f1c1f4d"` |  |
 | shardController.manager.resources.limits.cpu | string | `"500m"` |  |

--- a/charts/projectsveltos/templates/register-mgmt-cluster-job.yaml
+++ b/charts/projectsveltos/templates/register-mgmt-cluster-job.yaml
@@ -11,7 +11,7 @@ spec:
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-      {{- end }}    
+      {{- end }}
       containers:
       - args: {{- toYaml .Values.registerMgmtClusterJob.registerMgmtCluster.args
           | nindent 8 }}
@@ -21,7 +21,7 @@ spec:
         {{- with .Values.registerMgmtClusterJob.registerMgmtCluster.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        image: {{ .Values.registerMgmtClusterJob.registerMgmtCluster.image.repository 
+        image: {{ .Values.registerMgmtClusterJob.registerMgmtCluster.image.repository
            }}{{- if .Values.global.useDigest }}@{{ .Values.registerMgmtClusterJob.registerMgmtCluster.image.digest }}{{- else }}:{{ .Values.registerMgmtClusterJob.registerMgmtCluster.image.tag | default .Chart.AppVersion }}{{- end }}
         imagePullPolicy: {{ .Values.registerMgmtClusterJob.registerMgmtCluster.imagePullPolicy
           }}

--- a/charts/projectsveltos/values.yaml
+++ b/charts/projectsveltos/values.yaml
@@ -16,7 +16,7 @@ accessManager:
         drop:
           - ALL
     image:
-      repository: docker.io/projectsveltos/access-manager
+      repository: mirror.gcr.io/projectsveltos/access-manager
       tag: v0.49.0
       digest: sha256:1e96dbf30896ab2eb033e148fcaf01adb9d0ccefff5de1cb947c73939d5e7cf9
     resources:
@@ -59,7 +59,7 @@ addonController:
       seccompProfile:
         type: RuntimeDefault
     image:
-      repository: docker.io/projectsveltos/addon-controller
+      repository: mirror.gcr.io/projectsveltos/addon-controller
       tag: v0.49.0
       digest: sha256:1b65773d03eb864dd08a6f7c53b4f96333c49b420b3dea8446e5ecfb4878c7ca
     resources:
@@ -108,7 +108,7 @@ classifierManager:
         drop:
           - ALL
     image:
-      repository: docker.io/projectsveltos/classifier
+      repository: mirror.gcr.io/projectsveltos/classifier
       tag: v0.49.0
       digest: sha256:1009c617a5b33965ff97ec830b427b836e5a1ea13dd9df91228d12ed818ab61c
     resources:
@@ -143,7 +143,7 @@ eventManager:
         drop:
           - ALL
     image:
-      repository: docker.io/projectsveltos/event-manager
+      repository: mirror.gcr.io/projectsveltos/event-manager
       tag: v0.49.0
       digest: sha256:2a04eb744d78b6b1c15ecc90613558c4b553ced12d27ea1d2b829611f9d04939
     resources:
@@ -175,7 +175,7 @@ hcManager:
         drop:
           - ALL
     image:
-      repository: docker.io/projectsveltos/healthcheck-manager
+      repository: mirror.gcr.io/projectsveltos/healthcheck-manager
       tag: v0.49.0
       digest: sha256:94dce3b79405dac357430de39cfb1f596b4f148afb4d6f5dfcf2b6d4905931f6
     resources:
@@ -210,7 +210,7 @@ registerMgmtClusterJob:
         drop:
           - ALL
     image:
-      repository: docker.io/projectsveltos/register-mgmt-cluster
+      repository: mirror.gcr.io/projectsveltos/register-mgmt-cluster
       tag: v0.49.0
       digest: sha256:80056d75f1e4d63f40fa6c461e05e9361fb8dad2627e52bb2ac43d94ffdf332c
     imagePullPolicy: IfNotPresent
@@ -231,7 +231,7 @@ scManager:
         drop:
           - ALL
     image:
-      repository: docker.io/projectsveltos/sveltoscluster-manager
+      repository: mirror.gcr.io/projectsveltos/sveltoscluster-manager
       tag: v0.49.0
       digest: sha256:e486834d42ec6b98fa4772936d46c73edd54b954718757f0554b4332cb6993b4
     resources:
@@ -275,7 +275,7 @@ shardController:
         drop:
           - ALL
     image:
-      repository: docker.io/projectsveltos/shard-controller
+      repository: mirror.gcr.io/projectsveltos/shard-controller
       tag: v0.49.0
       digest: sha256:08797d8e786c51794dad98141f42a796d827bfae2e7db6d97fb7e9aa4f1c1f4d
     resources:

--- a/scripts/get_digest.sh
+++ b/scripts/get_digest.sh
@@ -11,7 +11,7 @@ get_image_digest() {
     return 1
   fi
 
-  image_name="docker.io/projectsveltos/$base_name:$tag"
+  image_name="mirror.gcr.io/projectsveltos/$base_name:$tag"
 
   digest=$(skopeo inspect --format '{{.Digest}}' "docker://$image_name" --override-os="linux" --override-arch="amd64" --override-variant="v8" 2>/dev/null)
 


### PR DESCRIPTION
Due to docker.io's rate limit of 10 pulls per hour, the image repository is now set to mirror.gcr.io for better reliability.