### PR TITLE
fix(crds): remove status blocks from templates to fix helm install

### DIFF
--- a/charts/crds/Chart.yaml
+++ b/charts/crds/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.1
+version: 1.2.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/crds/templates/accessrequest-crd.yaml
+++ b/charts/crds/templates/accessrequest-crd.yaml
@@ -135,9 +135,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/classifier-crd.yaml
+++ b/charts/crds/templates/classifier-crd.yaml
@@ -363,9 +363,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/classifierreport-crd.yaml
+++ b/charts/crds/templates/classifierreport-crd.yaml
@@ -85,9 +85,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/clusterconfiguration-crd.yaml
+++ b/charts/crds/templates/clusterconfiguration-crd.yaml
@@ -303,9 +303,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/clusterhealthcheck-crd.yaml
+++ b/charts/crds/templates/clusterhealthcheck-crd.yaml
@@ -435,9 +435,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/clusterprofile-crd.yaml
+++ b/charts/crds/templates/clusterprofile-crd.yaml
@@ -1394,9 +1394,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/clusterpromotion-crd.yaml
+++ b/charts/crds/templates/clusterpromotion-crd.yaml
@@ -1407,9 +1407,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/clusterreport-crd.yaml
+++ b/charts/crds/templates/clusterreport-crd.yaml
@@ -300,9 +300,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/clusterset-crd.yaml
+++ b/charts/crds/templates/clusterset-crd.yaml
@@ -245,9 +245,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/clustersummary-crd.yaml
+++ b/charts/crds/templates/clustersummary-crd.yaml
@@ -1415,9 +1415,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/configurationbundle-crd.yaml
+++ b/charts/crds/templates/configurationbundle-crd.yaml
@@ -134,9 +134,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/configurationgroup-crd.yaml
+++ b/charts/crds/templates/configurationgroup-crd.yaml
@@ -487,9 +487,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/debuggingconfiguration-crd.yaml
+++ b/charts/crds/templates/debuggingconfiguration-crd.yaml
@@ -85,9 +85,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/eventreport-crd.yaml
+++ b/charts/crds/templates/eventreport-crd.yaml
@@ -143,9 +143,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/eventsource-crd.yaml
+++ b/charts/crds/templates/eventsource-crd.yaml
@@ -192,9 +192,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/eventtrigger-crd.yaml
+++ b/charts/crds/templates/eventtrigger-crd.yaml
@@ -1565,9 +1565,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/healthcheck-crd.yaml
+++ b/charts/crds/templates/healthcheck-crd.yaml
@@ -155,9 +155,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/healthcheckreport-crd.yaml
+++ b/charts/crds/templates/healthcheckreport-crd.yaml
@@ -151,9 +151,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/profile-crd.yaml
+++ b/charts/crds/templates/profile-crd.yaml
@@ -1394,9 +1394,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/reloader-crd.yaml
+++ b/charts/crds/templates/reloader-crd.yaml
@@ -74,9 +74,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/reloaderreport-crd.yaml
+++ b/charts/crds/templates/reloaderreport-crd.yaml
@@ -108,9 +108,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/resourcesummary-crd.yaml
+++ b/charts/crds/templates/resourcesummary-crd.yaml
@@ -412,9 +412,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/rolerequest-crd.yaml
+++ b/charts/crds/templates/rolerequest-crd.yaml
@@ -273,9 +273,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/set-crd.yaml
+++ b/charts/crds/templates/set-crd.yaml
@@ -245,9 +245,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/sveltoscluster-crd.yaml
+++ b/charts/crds/templates/sveltoscluster-crd.yaml
@@ -435,9 +435,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/sveltoslicense-crd.yaml
+++ b/charts/crds/templates/sveltoslicense-crd.yaml
@@ -80,9 +80,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/crds/templates/techsupport-crd.yaml
+++ b/charts/crds/templates/techsupport-crd.yaml
@@ -550,9 +550,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
Fixes #151

## Problem
Helm install fails with "got unexpected nil transformer" on Kubernetes 1.25+ due to empty status blocks in CRD templates. The empty `acceptedNames.kind` and `acceptedNames.plural` fields cause nil pointer errors during Helm's 3-way merge.

## Solution
Removed explicit status blocks from all 27 CRD templates in `charts/crds/templates/`. Status fields are server-managed and should not be in templates. The Kubernetes API server generates them automatically after CRD validation.

## Changes
- Removed top-level `status:` blocks containing empty `acceptedNames`, `conditions`, and `storedVersions`
- Preserved all `spec.versions[].subresources.status: {}` declarations (required for CRD functionality)
- No other modifications to CRD specs, schemas, or metadata

## Testing
Tested on Kubernetes v1.32 with Helm v3:

**Installation**
- Fresh install: `helm install sveltos-crds` succeeds (previously failed)
- Upgrade: `helm upgrade sveltos-crds` works correctly
- Both charts tested: `sveltos-crds` and `projectsveltos`

**Verification**
- All 28 CRDs created successfully
- Status fields properly populated by API server (verified on accessrequests, clusterconfigurations, sveltosclusters, techsupports)
- `acceptedNames`, `conditions`, and `storedVersions` auto-generated with correct values
- Created and validated custom resource (Techsupport) - controller interaction confirmed

**Backward Compatibility**
- Previous workaround (`helm template | kubectl apply`) still works
- `kubectl apply --dry-run=server` validation unchanged
- No regressions

The original error is resolved. Helm install now works without workarounds.