### PR TITLE
feat(projectsveltos): add enabled flags for mcp server and techsupport

### DIFF
--- a/charts/projectsveltos/Chart.yaml
+++ b/charts/projectsveltos/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 1.3.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/projectsveltos/README.md
+++ b/charts/projectsveltos/README.md
@@ -240,6 +240,7 @@ Projectsveltos helm chart for Kubernetes
 | shardController.podSecurityContext.runAsNonRoot | bool | `true` |  |
 | shardController.tolerations | list | `[]` |  |
 | shardController.serviceAccount.annotations | object | `{}` |  |
+| techsupportController.enabled | bool | `true` |  |
 | techsupportController.annotations | object | `{}` |  |
 | techsupportController.labels | object | `{}` |  |
 | techsupportController.extraEnv | list | `[]` |  |
@@ -260,6 +261,7 @@ Projectsveltos helm chart for Kubernetes
 | techsupportController.podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | techsupportController.tolerations | list | `[]` |  |
 | techsupportController.serviceAccount.annotations | object | `{}` |  |
+| mcpServer.enabled | bool | `true` |  |
 | mcpServer.annotations | object | `{}` |  |
 | mcpServer.labels | object | `{}` |  |
 | mcpServer.controller.args[0] | string | `"--v=5"` |  |

--- a/charts/projectsveltos/templates/deployment.yaml
+++ b/charts/projectsveltos/templates/deployment.yaml
@@ -767,6 +767,7 @@ spec:
       securityContext: {{- toYaml .Values.shardController.podSecurityContext | nindent 8 }}
       serviceAccountName: shard-controller
       terminationGracePeriodSeconds: 10
+{{- if .Values.techsupportController.enabled }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -850,6 +851,8 @@ spec:
       securityContext: {{- toYaml .Values.shardController.podSecurityContext | nindent 8 }}
       serviceAccountName: techsupport-controller
       terminationGracePeriodSeconds: 10
+{{- end }}
+{{- if .Values.mcpServer.enabled }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -960,3 +963,4 @@ spec:
       volumes:
       - emptyDir: {}
         name: tmp
+{{- end }}

--- a/charts/projectsveltos/templates/mcp-server.yaml
+++ b/charts/projectsveltos/templates/mcp-server.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.mcpServer.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,3 +13,4 @@ spec:
     {{- include "projectsveltos.selectorLabels" . | nindent 4 }}
   ports:
   {{- .Values.mcpServer.ports | toYaml | nindent 2 }}
+{{- end }}

--- a/charts/projectsveltos/templates/serviceaccount.yaml
+++ b/charts/projectsveltos/templates/serviceaccount.yaml
@@ -94,6 +94,7 @@ metadata:
   {{- include "projectsveltos.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.registerMgmtCluster.serviceAccount.annotations | nindent 4 }}
+{{- if .Values.techsupportController.enabled }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -104,6 +105,8 @@ metadata:
   {{- include "projectsveltos.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.techsupportController.serviceAccount.annotations | nindent 4 }}
+{{- end }}
+{{- if .Values.mcpServer.enabled }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -113,6 +116,7 @@ metadata:
   {{- include "projectsveltos.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.mcpServer.serviceAccount.annotations | nindent 4 }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/projectsveltos/templates/sveltos-mcp-server-rbac.yaml
+++ b/charts/projectsveltos/templates/sveltos-mcp-server-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.mcpServer.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -28,3 +29,4 @@ subjects:
 - kind: ServiceAccount
   name: 'mcp-server'
   namespace: '{{ .Release.Namespace }}'
+{{- end }}

--- a/charts/projectsveltos/templates/techsupport-rbac.yaml
+++ b/charts/projectsveltos/templates/techsupport-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.techsupportController.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -70,3 +71,4 @@ subjects:
 - kind: ServiceAccount
   name: 'techsupport-controller'
   namespace: '{{ .Release.Namespace }}'
+{{- end }}

--- a/charts/projectsveltos/values.yaml
+++ b/charts/projectsveltos/values.yaml
@@ -357,6 +357,7 @@ shardController:
   serviceAccount:
     annotations: {}
 techsupportController:
+  enabled: true
   annotations: {}
   labels: {}
   extraEnv: []
@@ -390,6 +391,7 @@ techsupportController:
   serviceAccount:
     annotations: {}
 mcpServer:
+  enabled: true
   annotations: {}
   labels: {}
   controller:


### PR DESCRIPTION
This PR adds options to disable components that require a license to run correctly.

New users without a license can now opt out of deploying those components, making the chart installable without license-related failures.

When running:

```bash
helm template . \
  --set techsupportController.enabled=false \
  --set mcpServer.enabled=false
```

the diff is as follows:

```diff
diff --git a/charts/projectsveltos/result b/charts/projectsveltos/result
index c6e83d8..2f81b00 100644
--- a/charts/projectsveltos/result
+++ b/charts/projectsveltos/result
@@ -115,35 +115,6 @@ metadata:
   annotations:
     {}
 ---
-# Source: projectsveltos/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: techsupport-controller
-  labels:
-    control-plane: techsupport
-    helm.sh/chart: projectsveltos-1.2.1
-    app.kubernetes.io/name: projectsveltos
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.2.1"
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
----
-# Source: projectsveltos/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: mcp-server
-  labels:
-    helm.sh/chart: projectsveltos-1.2.1
-    app.kubernetes.io/name: projectsveltos
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.2.1"
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
----
 # Source: projectsveltos/templates/access-manager-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1454,90 +1425,6 @@ rules:
   verbs:
   - get
 ---
-# Source: projectsveltos/templates/sveltos-mcp-server-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: sveltos-mcp-server
-  labels:
-    helm.sh/chart: projectsveltos-1.2.1
-    app.kubernetes.io/name: projectsveltos
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.2.1"
-    app.kubernetes.io/managed-by: Helm
-rules:
-- apiGroups:
-  - '*'
-  resources:
-  - '*'
-  verbs:
-  - get
-  - list
-  - watch
----
-# Source: projectsveltos/templates/techsupport-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: techsupport-role
-  labels:
-    helm.sh/chart: projectsveltos-1.2.1
-    app.kubernetes.io/name: projectsveltos
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.2.1"
-    app.kubernetes.io/managed-by: Helm
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - '*'
-  resources:
-  - '*'
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - lib.projectsveltos.io
-  resources:
-  - debuggingconfigurations
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - lib.projectsveltos.io
-  resources:
-  - techsupports
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - lib.projectsveltos.io
-  resources:
-  - techsupports/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - lib.projectsveltos.io
-  resources:
-  - techsupports/status
-  verbs:
-  - get
-  - patch
-  - update
----
 # Source: projectsveltos/templates/access-manager-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1721,46 +1608,6 @@ subjects:
   name: 'shard-controller'
   namespace: 'default'
 ---
-# Source: projectsveltos/templates/sveltos-mcp-server-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: sveltos-mcp-server
-  labels:
-    helm.sh/chart: projectsveltos-1.2.1
-    app.kubernetes.io/name: projectsveltos
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.2.1"
-    app.kubernetes.io/managed-by: Helm
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: 'sveltos-mcp-server'
-subjects:
-- kind: ServiceAccount
-  name: 'mcp-server'
-  namespace: 'default'
----
-# Source: projectsveltos/templates/techsupport-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: techsupport-rolebinding
-  labels:
-    helm.sh/chart: projectsveltos-1.2.1
-    app.kubernetes.io/name: projectsveltos
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.2.1"
-    app.kubernetes.io/managed-by: Helm
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: 'techsupport-role'
-subjects:
-- kind: ServiceAccount
-  name: 'techsupport-controller'
-  namespace: 'default'
----
 # Source: projectsveltos/templates/addon-controller-role-extra-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -1866,30 +1713,6 @@ spec:
     protocol: TCP
     targetPort: 8443
 ---
-# Source: projectsveltos/templates/mcp-server.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: mcp-server
-  labels:
-    control-plane: mcp-server
-    helm.sh/chart: projectsveltos-1.2.1
-    app.kubernetes.io/name: projectsveltos
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.2.1"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  selector:
-    control-plane: mcp-server
-    app.kubernetes.io/name: projectsveltos
-    app.kubernetes.io/instance: release-name
-  ports:
-  - name: metrics
-    port: 80
-    protocol: TCP
-    targetPort: 8080
----
 # Source: projectsveltos/templates/sc-manager.yaml
 apiVersion: v1
 kind: Service
@@ -2490,163 +2313,6 @@ spec:
       serviceAccountName: shard-controller
       terminationGracePeriodSeconds: 10
 ---
-# Source: projectsveltos/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: techsupport-controller
-  labels:
-    control-plane: techsupport
-    helm.sh/chart: projectsveltos-1.2.1
-    app.kubernetes.io/name: projectsveltos
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.2.1"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      control-plane: techsupport
-      app.kubernetes.io/name: projectsveltos
-      app.kubernetes.io/instance: release-name
-  template:
-    metadata:
-      labels:
-        control-plane: techsupport
-        app.kubernetes.io/name: projectsveltos
-        app.kubernetes.io/instance: release-name
-    spec:
-      containers:
-      - args:
-        - --v=5
-        command:
-        - /manager
-        env:
-        - name: KUBERNETES_CLUSTER_DOMAIN
-          value: "cluster.local"
-        image: docker.io/projectsveltos/techsupport:v1.2.1
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8081
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        name: controller
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8081
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        resources:
-          limits:
-            cpu: 500m
-            memory: 512Mi
-          requests:
-            cpu: 10m
-            memory: 128Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-      securityContext:
-        runAsNonRoot: true
-      serviceAccountName: techsupport-controller
-      terminationGracePeriodSeconds: 10
----
-# Source: projectsveltos/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: mcp-server
-  labels:
-    control-plane: mcp-server
-    helm.sh/chart: projectsveltos-1.2.1
-    app.kubernetes.io/name: projectsveltos
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.2.1"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      control-plane: mcp-server
-      app.kubernetes.io/name: projectsveltos
-      app.kubernetes.io/instance: release-name
-  template:
-    metadata:
-      labels:
-        control-plane: mcp-server
-        app.kubernetes.io/name: projectsveltos
-        app.kubernetes.io/instance: release-name
-      annotations:
-        kubectl.kubernetes.io/default-container: controller
-    spec:
-      containers:
-      - args:
-        - --v=5
-        command:
-        - /manager
-        env:
-        - name: GOMEMLIMIT
-          valueFrom:
-            resourceFieldRef:
-              divisor: "0"
-              resource: limits.memory
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              divisor: "0"
-              resource: limits.cpu
-        - name: KUBERNETES_CLUSTER_DOMAIN
-          value: "cluster.local"
-        image: docker.io/projectsveltos/mcp-server:v1.2.1
-        imagePullPolicy: 
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /healthz
-            port: mcp
-            scheme: HTTP
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        name: controller
-        ports:
-        - containerPort: 8080
-          name: mcp
-          protocol: TCP
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /readyz
-            port: mcp
-            scheme: HTTP
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        resources:
-          limits:
-            cpu: 500m
-            memory: 1024Mi
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-        volumeMounts:
-        - mountPath: /tmp
-          name: tmp
-      securityContext:
-        runAsNonRoot: true
-      serviceAccountName: mcp-server
-      terminationGracePeriodSeconds: 10
-      volumes:
-      - emptyDir: {}
-        name: tmp
----
 # Source: projectsveltos/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
```