### PR TITLE
feat(projectsveltos): add enabled flags for access-manager and shard-controller

### DIFF
--- a/charts/projectsveltos/Chart.yaml
+++ b/charts/projectsveltos/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.1
+version: 1.3.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/projectsveltos/README.md
+++ b/charts/projectsveltos/README.md
@@ -15,6 +15,7 @@ Projectsveltos helm chart for Kubernetes
 | global.additionalLabels | object | `{}` |  |
 | accessManager.annotations | object | `{}` |  |
 | accessManager.labels | object | `{}` |  |
+| accessManager.enabled | bool | `true` |  |
 | accessManager.manager.args[0] | string | `"--diagnostics-address=:8443"` |  |
 | accessManager.manager.args[1] | string | `"--v=5"` |  |
 | accessManager.manager.extraArgs | object | `{}` |  |
@@ -214,6 +215,7 @@ Projectsveltos helm chart for Kubernetes
 | scManager.tolerations | list | `[]` |  |
 | scManager.serviceAccount.annotations | object | `{}` |  |
 | scManager.type | string | `"ClusterIP"` |  |
+| shardController.enabled | bool | `true` |  |
 | shardController.annotations | object | `{}` |  |
 | shardController.labels | object | `{}` |  |
 | shardController.extraEnv | list | `[]` |  |

--- a/charts/projectsveltos/templates/access-manager-rbac.yaml
+++ b/charts/projectsveltos/templates/access-manager-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.accessManager.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -155,3 +156,4 @@ subjects:
 - kind: ServiceAccount
   name: 'access-manager'
   namespace: '{{ .Release.Namespace }}'
+{{- end }}

--- a/charts/projectsveltos/templates/deployment.yaml
+++ b/charts/projectsveltos/templates/deployment.yaml
@@ -132,6 +132,7 @@ spec:
       volumes:
       - emptyDir: {}
         name: tmp
+{{ if .Values.accessManager.enabled }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -227,6 +228,7 @@ spec:
       securityContext: {{- toYaml .Values.accessManager.podSecurityContext | nindent 8 }}
       serviceAccountName: access-manager
       terminationGracePeriodSeconds: 10
+{{ end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -659,6 +661,7 @@ spec:
       securityContext: {{- toYaml .Values.classifierManager.podSecurityContext | nindent 8 }}
       serviceAccountName: classifier-manager
       terminationGracePeriodSeconds: 10
+{{ if .Values.shardController.enabled }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -767,6 +770,7 @@ spec:
       securityContext: {{- toYaml .Values.shardController.podSecurityContext | nindent 8 }}
       serviceAccountName: shard-controller
       terminationGracePeriodSeconds: 10
+{{ end }}
 {{- if .Values.techsupportController.enabled }}
 ---
 apiVersion: apps/v1

--- a/charts/projectsveltos/templates/serviceaccount.yaml
+++ b/charts/projectsveltos/templates/serviceaccount.yaml
@@ -6,6 +6,7 @@ metadata:
   {{- include "projectsveltos.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.addonController.serviceAccount.annotations | nindent 4 }}
+{{ if .Values.accessManager.enabled }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -15,6 +16,7 @@ metadata:
   {{- include "projectsveltos.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.accessManager.serviceAccount.annotations | nindent 4 }}
+{{ end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -73,6 +75,7 @@ metadata:
   annotations:
     {{- toYaml .Values.driftDetectionManager.serviceAccount.annotations | nindent 4 }}
 {{ end }}
+{{ if .Values.shardController.enabled }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -85,6 +88,7 @@ metadata:
   {{- include "projectsveltos.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.shardController.serviceAccount.annotations | nindent 4 }}
+{{ end }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/projectsveltos/templates/shard-controller-role-extra-rbac.yaml
+++ b/charts/projectsveltos/templates/shard-controller-role-extra-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.shardController.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -11,3 +12,4 @@ rules:
   - deployments
   verbs:
   - '*'
+{{- end }}

--- a/charts/projectsveltos/templates/shard-controller-rolebinding-extra-rbac.yaml
+++ b/charts/projectsveltos/templates/shard-controller-rolebinding-extra-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.shardController.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -12,3 +13,4 @@ subjects:
 - kind: ServiceAccount
   name: 'shard-controller'
   namespace: '{{ .Release.Namespace }}'
+{{- end }}

--- a/charts/projectsveltos/templates/shard-manager-rbac.yaml
+++ b/charts/projectsveltos/templates/shard-manager-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.shardController.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -72,3 +73,4 @@ subjects:
 - kind: ServiceAccount
   name: 'shard-controller'
   namespace: '{{ .Release.Namespace }}'
+{{- end }}

--- a/charts/projectsveltos/values.yaml
+++ b/charts/projectsveltos/values.yaml
@@ -6,6 +6,7 @@ global:
     # - name: my-registry-secret
   additionalLabels: {}
 accessManager:
+  enabled: true
   annotations: {}
   labels: {}
   manager:
@@ -318,6 +319,7 @@ scManager:
     annotations: {}
   type: ClusterIP
 shardController:
+  enabled: true
   annotations: {}
   labels: {}
   extraEnv: []


### PR DESCRIPTION
## `helm template . --set accessManager.enabled=false`

```diff
--- a/charts/projectsveltos/result
+++ b/charts/projectsveltos/result
@@ -16,20 +16,6 @@ metadata:
 # Source: projectsveltos/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-metadata:
-  name: access-manager
-  labels:
-    helm.sh/chart: projectsveltos-1.3.2
-    app.kubernetes.io/name: projectsveltos
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.3.0"
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
----
-# Source: projectsveltos/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
 metadata:
   name: sc-manager
   labels:
@@ -144,154 +130,6 @@ metadata:
   annotations:
     {}
 ---
-# Source: projectsveltos/templates/access-manager-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: access-manager-role
-  labels:
-    helm.sh/chart: projectsveltos-1.3.2
-    app.kubernetes.io/name: projectsveltos
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.3.0"
-    app.kubernetes.io/managed-by: Helm
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  - serviceaccounts
-  - serviceaccounts/token
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
-- apiGroups:
-  - cluster.x-k8s.io
-  resources:
-  - clusters
-  - clusters/status
-  - machines
-  - machines/status
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - lib.projectsveltos.io
-  resources:
-  - accessrequests
-  verbs:
-  - get
-  - list
-  - patch
-  - watch
-- apiGroups:
-  - lib.projectsveltos.io
-  resources:
-  - accessrequests/finalizers
-  - rolerequests/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - lib.projectsveltos.io
-  resources:
-  - accessrequests/status
-  - rolerequests/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - lib.projectsveltos.io
-  resources:
-  - classifierreports
-  - eventreports
-  - healthcheckreports
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - lib.projectsveltos.io
-  resources:
-  - configurationbundles
-  - configurationgroups
-  - rolerequests
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - lib.projectsveltos.io
-  resources:
-  - configurationbundles/status
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - lib.projectsveltos.io
-  resources:
-  - configurationgroups/status
-  - debuggingconfigurations
-  - sveltosclusters
-  - sveltosclusters/status
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - rolebindings
-  - roles
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - watch
----
 # Source: projectsveltos/templates/addon-clusterconfiguration-editor-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1538,26 +1376,6 @@ rules:
   - patch
   - update
 ---
-# Source: projectsveltos/templates/access-manager-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: access-manager-rolebinding
-  labels:
-    helm.sh/chart: projectsveltos-1.3.2
-    app.kubernetes.io/name: projectsveltos
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.3.0"
-    app.kubernetes.io/managed-by: Helm
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: 'access-manager-role'
-subjects:
-- kind: ServiceAccount
-  name: 'access-manager'
-  namespace: 'default'
----
 # Source: projectsveltos/templates/addon-controller-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -2015,84 +1833,6 @@ spec:
 # Source: projectsveltos/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
-metadata:
-  name: access-manager
-  labels:
-    control-plane: access-manager
-    helm.sh/chart: projectsveltos-1.3.2
-    app.kubernetes.io/name: projectsveltos
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.3.0"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      control-plane: access-manager
-      app.kubernetes.io/name: projectsveltos
-      app.kubernetes.io/instance: release-name
-  template:
-    metadata:
-      labels:
-        control-plane: access-manager
-        app.kubernetes.io/name: projectsveltos
-        app.kubernetes.io/instance: release-name
-    spec:
-      containers:
-      - args:
-        - --diagnostics-address=:8443
-        - --v=5
-        - --capi-onboard-annotation=
-        command:
-        - /manager
-        env:
-        - name: KUBERNETES_CLUSTER_DOMAIN
-          value: "cluster.local"
-        image: docker.io/projectsveltos/access-manager:v1.3.0
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /healthz
-            port: healthz
-            scheme: HTTP
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        name: manager
-        ports:
-        - containerPort: 8443
-          name: metrics
-          protocol: TCP
-        - containerPort: 9440
-          name: healthz
-          protocol: TCP
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /readyz
-            port: healthz
-            scheme: HTTP
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        resources:
-          limits:
-            cpu: 500m
-            memory: 512Mi
-          requests:
-            cpu: 10m
-            memory: 128Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-      securityContext:
-        runAsNonRoot: true
-      serviceAccountName: access-manager
-      terminationGracePeriodSeconds: 10
----
-# Source: projectsveltos/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
 metadata:
   name: sc-manager
   labels:
```

## `helm template . --set accessManager.enabled=false`

```diff
--- a/charts/projectsveltos/result
+++ b/charts/projectsveltos/result
@@ -87,23 +87,6 @@ metadata:
 ---
 apiVersion: v1
 kind: ServiceAccount
-metadata:
-  name: shard-controller
-  labels:
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: shard-controller
-    app.kubernetes.io/part-of: shard-controller
-    helm.sh/chart: projectsveltos-1.3.2
-    app.kubernetes.io/name: projectsveltos
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.3.0"
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-    {}
----
-# Source: projectsveltos/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
 metadata:
   name: register-mgmt-cluster
   labels:
@@ -1392,68 +1375,6 @@ rules:
   - patch
   - update
 ---
-# Source: projectsveltos/templates/shard-manager-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: shard-manager-role
-  labels:
-    helm.sh/chart: projectsveltos-1.3.2
-    app.kubernetes.io/name: projectsveltos
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.3.0"
-    app.kubernetes.io/managed-by: Helm
-rules:
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
-- apiGroups:
-  - cluster.x-k8s.io
-  resources:
-  - clusters
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - cluster.x-k8s.io
-  resources:
-  - clusters/status
-  verbs:
-  - get
-- apiGroups:
-  - lib.projectsveltos.io
-  resources:
-  - debuggingconfigurations
-  - sveltosclusters
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - lib.projectsveltos.io
-  resources:
-  - sveltosclusters/status
-  verbs:
-  - get
----
 # Source: projectsveltos/templates/sveltos-mcp-server-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1698,29 +1619,6 @@ subjects:
   name: 'sc-manager'
   namespace: 'default'
 ---
-# Source: projectsveltos/templates/shard-manager-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: shard-manager-rolebinding
-  labels:
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: shard-controller
-    app.kubernetes.io/part-of: shard-controller
-    helm.sh/chart: projectsveltos-1.3.2
-    app.kubernetes.io/name: projectsveltos
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.3.0"
-    app.kubernetes.io/managed-by: Helm
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: 'shard-manager-role'
-subjects:
-- kind: ServiceAccount
-  name: 'shard-controller'
-  namespace: 'default'
----
 # Source: projectsveltos/templates/sveltos-mcp-server-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1783,25 +1681,6 @@ rules:
   - create
   - update
 ---
-# Source: projectsveltos/templates/shard-controller-role-extra-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: shard-controller-role-extra
-  labels:
-    helm.sh/chart: projectsveltos-1.3.2
-    app.kubernetes.io/name: projectsveltos
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.3.0"
-    app.kubernetes.io/managed-by: Helm
-rules:
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - '*'
----
 # Source: projectsveltos/templates/addon-controller-rolebinding-extra-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -1822,26 +1701,6 @@ subjects:
   name: 'addon-controller'
   namespace: 'default'
 ---
-# Source: projectsveltos/templates/shard-controller-rolebinding-extra-rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: shard-controller-rolebinding-extra
-  labels:
-    helm.sh/chart: projectsveltos-1.3.2
-    app.kubernetes.io/name: projectsveltos
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.3.0"
-    app.kubernetes.io/managed-by: Helm
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: 'shard-controller-role-extra'
-subjects:
-- kind: ServiceAccount
-  name: 'shard-controller'
-  namespace: 'default'
----
 # Source: projectsveltos/templates/addon-controller.yaml
 apiVersion: v1
 kind: Service
@@ -2415,84 +2274,6 @@ spec:
 # Source: projectsveltos/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
-metadata:
-  name: shard-controller
-  labels:
-    control-plane: shard-controller
-    helm.sh/chart: projectsveltos-1.3.2
-    app.kubernetes.io/name: projectsveltos
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.3.0"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      control-plane: shard-controller
-      app.kubernetes.io/name: projectsveltos
-      app.kubernetes.io/instance: release-name
-  template:
-    metadata:
-      labels:
-        control-plane: shard-controller
-        app.kubernetes.io/name: projectsveltos
-        app.kubernetes.io/instance: release-name
-    spec:
-      containers:
-      - args:
-        - --diagnostics-address=:8443
-        - --v=5
-        - --report-mode=0
-        command:
-        - /manager
-        env:
-        - name: KUBERNETES_CLUSTER_DOMAIN
-          value: "cluster.local"
-        image: docker.io/projectsveltos/shard-controller:v1.3.0
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /healthz
-            port: healthz
-            scheme: HTTP
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        name: manager
-        ports:
-        - containerPort: 8443
-          name: metrics
-          protocol: TCP
-        - containerPort: 9440
-          name: healthz
-          protocol: TCP
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /readyz
-            port: healthz
-            scheme: HTTP
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        resources:
-          limits:
-            cpu: 500m
-            memory: 512Mi
-          requests:
-            cpu: 10m
-            memory: 128Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-      securityContext:
-        runAsNonRoot: true
-      serviceAccountName: shard-controller
-      terminationGracePeriodSeconds: 10
----
-# Source: projectsveltos/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
 metadata:
   name: techsupport-controller
   labels:
```