### PR TITLE
fix(event-manager): use toYaml for podSecurityContext

### DIFF
--- a/charts/projectsveltos/Chart.yaml
+++ b/charts/projectsveltos/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.3
+version: 1.3.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/projectsveltos/templates/deployment.yaml
+++ b/charts/projectsveltos/templates/deployment.yaml
@@ -538,8 +538,7 @@ spec:
         resources: {{- toYaml .Values.eventManager.manager.resources | nindent 10 }}
         securityContext: {{- toYaml .Values.eventManager.manager.containerSecurityContext
           | nindent 10 }}
-      securityContext:
-        runAsNonRoot: true
+      securityContext: {{- toYaml .Values.eventManager.podSecurityContext | nindent 8 }}
       serviceAccountName: event-manager
       terminationGracePeriodSeconds: 10
 ---


### PR DESCRIPTION
## Summary

The event-manager deployment had a hardcoded `securityContext` with only `runAsNonRoot: true`, ignoring the `podSecurityContext` values from `values.yaml`. This prevented users from setting `runAsUser` or other security context options.

## Changes

Changed from:
```yaml
securityContext:
  runAsNonRoot: true
```

To:
```yaml
securityContext: {{- toYaml .Values.eventManager.podSecurityContext | nindent 8 }}
```

## Impact

This fix allows users to configure the full `podSecurityContext` for the event-manager deployment, which is necessary for clusters enforcing Pod Security Standards that require non-root containers with explicit `runAsUser`.

## Testing

Verified the fix by templating the chart with custom podSecurityContext values:

```bash
helm template test ./charts/projectsveltos \
  --set eventManager.podSecurityContext.runAsUser=65532 \
  --set eventManager.podSecurityContext.runAsNonRoot=true
```

Fixes: #158