### PR TITLE
fix(techsupport-controller): use correct values reference

### DIFF
--- a/charts/projectsveltos/Chart.yaml
+++ b/charts/projectsveltos/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.3
+version: 1.3.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/projectsveltos/templates/deployment.yaml
+++ b/charts/projectsveltos/templates/deployment.yaml
@@ -849,10 +849,10 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-        resources: {{- toYaml .Values.shardController.manager.resources | nindent 10 }}
+        resources: {{- toYaml .Values.techsupportController.controller.resources | nindent 10 }}
         securityContext: {{- toYaml .Values.techsupportController.controller.containerSecurityContext
           | nindent 10 }}
-      securityContext: {{- toYaml .Values.shardController.podSecurityContext | nindent 8 }}
+      securityContext: {{- toYaml .Values.techsupportController.podSecurityContext | nindent 8 }}
       serviceAccountName: techsupport-controller
       terminationGracePeriodSeconds: 10
 {{- end }}


### PR DESCRIPTION
## Summary

The techsupport-controller deployment was incorrectly referencing `shardController` values for `resources` and `podSecurityContext` instead of `techsupportController` values.

## Changes

| Field | Before | After |
|-------|--------|-------|
| resources | `.Values.shardController.manager.resources` | `.Values.techsupportController.controller.resources` |
| securityContext | `.Values.shardController.podSecurityContext` | `.Values.techsupportController.podSecurityContext` |

## Impact

This ensures the techsupport-controller deployment uses its own configuration values rather than inheriting from shardController. Users can now properly configure:
- Resource limits/requests specific to techsupport-controller
- Pod security context for techsupport-controller (runAsUser, runAsNonRoot, fsGroup, etc.)

## Testing

Verified by templating the chart with custom techsupportController values:

```bash
helm template test ./charts/projectsveltos \
  --set techsupportController.controller.resources.limits.memory=1Gi \
  --set techsupportController.podSecurityContext.runAsUser=65532
```

Related to: #158