### PR TITLE
Adds support for annotations on the service

### DIFF
--- a/charts/dashboard/templates/dashboard.yaml
+++ b/charts/dashboard/templates/dashboard.yaml
@@ -4,6 +4,12 @@ metadata:
   name: dashboard
   labels:
   {{- include "projectsveltos.labels" . | nindent 4 }}
+  {{- with .Values.dashboard.annotations }}
+  annotations:
+  {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.dashboard.type }}
   selector:

--- a/charts/dashboard/values.yaml
+++ b/charts/dashboard/values.yaml
@@ -3,6 +3,7 @@ global:
   useDigest: false
   imagePullSecrets: []
 dashboard:
+  annotations: {}
   dashboard:
     image:
       repository: projectsveltos/dashboard


### PR DESCRIPTION
I will note that I did not add this to the README.md. I ran helm-docs on it, and it had a lot of other changes that were unrelated, so I was hesitant to add those changes. If you would like, I can manaully add the annotation field in the README.md, or I can add whatever helm-docs produced. Just let me know. 