### PR TITLE
fixed securityContext defined twice

### DIFF
--- a/charts/projectsveltos/Chart.yaml
+++ b/charts/projectsveltos/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.1
+version: 1.5.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/projectsveltos/templates/deployment.yaml
+++ b/charts/projectsveltos/templates/deployment.yaml
@@ -172,8 +172,6 @@ spec:
         image: {{ .Values.global.registry }}/{{ .Values.addonController.initialization.image.repository }}{{- if .Values.global.useDigest }}@{{ .Values.addonController.initialization.image.digest }}{{- else }}:{{ .Values.addonController.initialization.image.tag | default .Chart.AppVersion }}{{- end }}
         name: initialization
         resources: {}
-      securityContext: {{- toYaml .Values.addonController.podSecurityContext | nindent
-        8 }}
       serviceAccountName: addon-controller
       terminationGracePeriodSeconds: 10
       volumes:


### PR DESCRIPTION
Regarding https://github.com/projectsveltos/helm-charts/issues/167 I've removed securityContext which is was defined twice on addon-controller Deployment on **projectsveltos/projectsveltos** 1.5.1 helm chart