### PR TITLE
Adds in ability to assign resources to addon-controller initialization container

### DIFF
--- a/charts/projectsveltos/templates/deployment.yaml
+++ b/charts/projectsveltos/templates/deployment.yaml
@@ -171,7 +171,7 @@ spec:
           value: {{ quote .Values.kubernetesClusterDomain }}
         image: {{ .Values.global.registry }}/{{ .Values.addonController.initialization.image.repository }}{{- if .Values.global.useDigest }}@{{ .Values.addonController.initialization.image.digest }}{{- else }}:{{ .Values.addonController.initialization.image.tag | default .Chart.AppVersion }}{{- end }}
         name: initialization
-        resources: {}
+        resources: {{- toYaml .Values.addonController.initialization.resources | nindent 10 }}
       serviceAccountName: addon-controller
       terminationGracePeriodSeconds: 10
       volumes:

--- a/charts/projectsveltos/values.yaml
+++ b/charts/projectsveltos/values.yaml
@@ -45,6 +45,13 @@ addonController:
       repository: projectsveltos/addon-controller
       tag: v1.5.1
       digest: sha256:b63bef982f0a82a430a34f853a0707b5fde5c43adcbbcd5b5a1390875f99bfa5
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 10m
+        memory: 128Mi
   controller:
     args:
       - --diagnostics-address=:8443


### PR DESCRIPTION
Prior the new addon-controller initialization container had empty resources. Now with this change, you have the ability to set it yourself. And it sets a default if you don't set it.