### PR TITLE
Release v1.8.0

### DIFF
--- a/charts/crds/Chart.yaml
+++ b/charts/crds/Chart.yaml
@@ -13,10 +13,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.0
+version: 1.8.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.7.0"
+appVersion: "1.8.0"
 icon: https://github.com/projectsveltos/sveltos/raw/main/docs/assets/logo.png

--- a/charts/crds/templates/clusterprofile-crd.yaml
+++ b/charts/crds/templates/clusterprofile-crd.yaml
@@ -338,6 +338,16 @@ spec:
                           description: PassCredentialsAll is the flag to pass credentials
                             to all domains
                           type: boolean
+                        runTests:
+                          default: false
+                          description: |-
+                            RunTests if set to true, Sveltos will run helm test after each successful install or upgrade
+                            operation. The tests are the test hooks defined in the chart (annotated with
+                            "helm.sh/hook: test"). If any test fails the deployment is considered failed and the
+                            error is surfaced in the ClusterSummary status, providing operational gating.
+                            Has no effect in DryRun mode.
+                            Default to false
+                          type: boolean
                         skipCRDs:
                           default: false
                           description: |-
@@ -705,6 +715,16 @@ spec:
                         When expressed as templates, the values are filled in using information from
                         resources within the management cluster before deployment (Cluster)
                       type: string
+                    skipNamespaceCreation:
+                      default: false
+                      description: |-
+                        SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                        for namespaced resources defined in this KustomizationRef.
+                        This field is ignored for cluster-scoped resources.
+                        By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                        Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                        permissions to manage namespaces at the cluster level.
+                      type: boolean
                     targetNamespace:
                       description: |-
                         TargetNamespace sets or overrides the namespace in the
@@ -989,6 +1009,16 @@ spec:
                         Defaults to 'None', which translates to the root path of the SourceRef.
                         Used only for GitRepository;OCIRepository;Bucket
                       type: string
+                    skipNamespaceCreation:
+                      default: false
+                      description: |-
+                        SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                        for namespaced resources defined in this PolicyRef.
+                        This field is ignored for cluster-scoped resources.
+                        By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                        Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                        permissions to manage namespaces at the cluster level.
+                      type: boolean
                     tier:
                       default: 100
                       description: |-

--- a/charts/crds/templates/clusterpromotion-crd.yaml
+++ b/charts/crds/templates/clusterpromotion-crd.yaml
@@ -240,6 +240,16 @@ spec:
                               description: PassCredentialsAll is the flag to pass credentials
                                 to all domains
                               type: boolean
+                            runTests:
+                              default: false
+                              description: |-
+                                RunTests if set to true, Sveltos will run helm test after each successful install or upgrade
+                                operation. The tests are the test hooks defined in the chart (annotated with
+                                "helm.sh/hook: test"). If any test fails the deployment is considered failed and the
+                                error is surfaced in the ClusterSummary status, providing operational gating.
+                                Has no effect in DryRun mode.
+                                Default to false
+                              type: boolean
                             skipCRDs:
                               default: false
                               description: |-
@@ -608,6 +618,16 @@ spec:
                             When expressed as templates, the values are filled in using information from
                             resources within the management cluster before deployment (Cluster)
                           type: string
+                        skipNamespaceCreation:
+                          default: false
+                          description: |-
+                            SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                            for namespaced resources defined in this KustomizationRef.
+                            This field is ignored for cluster-scoped resources.
+                            By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                            Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                            permissions to manage namespaces at the cluster level.
+                          type: boolean
                         targetNamespace:
                           description: |-
                             TargetNamespace sets or overrides the namespace in the
@@ -892,6 +912,16 @@ spec:
                             Defaults to 'None', which translates to the root path of the SourceRef.
                             Used only for GitRepository;OCIRepository;Bucket
                           type: string
+                        skipNamespaceCreation:
+                          default: false
+                          description: |-
+                            SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                            for namespaced resources defined in this PolicyRef.
+                            This field is ignored for cluster-scoped resources.
+                            By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                            Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                            permissions to manage namespaces at the cluster level.
+                          type: boolean
                         tier:
                           default: 100
                           description: |-
@@ -1609,6 +1639,16 @@ spec:
                                       Defaults to 'None', which translates to the root path of the SourceRef.
                                       Used only for GitRepository;OCIRepository;Bucket
                                     type: string
+                                  skipNamespaceCreation:
+                                    default: false
+                                    description: |-
+                                      SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                                      for namespaced resources defined in this PolicyRef.
+                                      This field is ignored for cluster-scoped resources.
+                                      By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                                      Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                                      permissions to manage namespaces at the cluster level.
+                                    type: boolean
                                   tier:
                                     default: 100
                                     description: |-
@@ -1839,6 +1879,16 @@ spec:
                                       Defaults to 'None', which translates to the root path of the SourceRef.
                                       Used only for GitRepository;OCIRepository;Bucket
                                     type: string
+                                  skipNamespaceCreation:
+                                    default: false
+                                    description: |-
+                                      SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                                      for namespaced resources defined in this PolicyRef.
+                                      This field is ignored for cluster-scoped resources.
+                                      By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                                      Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                                      permissions to manage namespaces at the cluster level.
+                                    type: boolean
                                   tier:
                                     default: 100
                                     description: |-

--- a/charts/crds/templates/clustersummary-crd.yaml
+++ b/charts/crds/templates/clustersummary-crd.yaml
@@ -376,6 +376,16 @@ spec:
                               description: PassCredentialsAll is the flag to pass credentials
                                 to all domains
                               type: boolean
+                            runTests:
+                              default: false
+                              description: |-
+                                RunTests if set to true, Sveltos will run helm test after each successful install or upgrade
+                                operation. The tests are the test hooks defined in the chart (annotated with
+                                "helm.sh/hook: test"). If any test fails the deployment is considered failed and the
+                                error is surfaced in the ClusterSummary status, providing operational gating.
+                                Has no effect in DryRun mode.
+                                Default to false
+                              type: boolean
                             skipCRDs:
                               default: false
                               description: |-
@@ -744,6 +754,16 @@ spec:
                             When expressed as templates, the values are filled in using information from
                             resources within the management cluster before deployment (Cluster)
                           type: string
+                        skipNamespaceCreation:
+                          default: false
+                          description: |-
+                            SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                            for namespaced resources defined in this KustomizationRef.
+                            This field is ignored for cluster-scoped resources.
+                            By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                            Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                            permissions to manage namespaces at the cluster level.
+                          type: boolean
                         targetNamespace:
                           description: |-
                             TargetNamespace sets or overrides the namespace in the
@@ -1028,6 +1048,16 @@ spec:
                             Defaults to 'None', which translates to the root path of the SourceRef.
                             Used only for GitRepository;OCIRepository;Bucket
                           type: string
+                        skipNamespaceCreation:
+                          default: false
+                          description: |-
+                            SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                            for namespaced resources defined in this PolicyRef.
+                            This field is ignored for cluster-scoped resources.
+                            By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                            Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                            permissions to manage namespaces at the cluster level.
+                          type: boolean
                         tier:
                           default: 100
                           description: |-
@@ -1648,6 +1678,11 @@ spec:
                     failureMessage:
                       description: FailureMessage provides the specific error from the
                         Helm engine for this release
+                      type: string
+                    patchesHash:
+                      description: PatchesHash represents of a unique value for the
+                        patches section
+                      format: byte
                       type: string
                     releaseName:
                       description: ReleaseName is the chart release

--- a/charts/crds/templates/configurationbundle-crd.yaml
+++ b/charts/crds/templates/configurationbundle-crd.yaml
@@ -116,6 +116,16 @@ spec:
                   type: string
                 type: array
                 x-kubernetes-list-type: atomic
+              skipNamespaceCreation:
+                default: false
+                description: |-
+                  SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                  for namespaced resources defined in this PolicyRef.
+                  This field is ignored for cluster-scoped resources.
+                  By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                  Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                  permissions to manage namespaces at the cluster level.
+                type: boolean
               timeout:
                 description: time to wait for Kubernetes operation (like Jobs for hooks)
                 type: string

--- a/charts/crds/templates/eventtrigger-crd.yaml
+++ b/charts/crds/templates/eventtrigger-crd.yaml
@@ -414,6 +414,16 @@ spec:
                           description: PassCredentialsAll is the flag to pass credentials
                             to all domains
                           type: boolean
+                        runTests:
+                          default: false
+                          description: |-
+                            RunTests if set to true, Sveltos will run helm test after each successful install or upgrade
+                            operation. The tests are the test hooks defined in the chart (annotated with
+                            "helm.sh/hook: test"). If any test fails the deployment is considered failed and the
+                            error is surfaced in the ClusterSummary status, providing operational gating.
+                            Has no effect in DryRun mode.
+                            Default to false
+                          type: boolean
                         skipCRDs:
                           default: false
                           description: |-
@@ -782,6 +792,16 @@ spec:
                         When expressed as templates, the values are filled in using information from
                         resources within the management cluster before deployment (Cluster)
                       type: string
+                    skipNamespaceCreation:
+                      default: false
+                      description: |-
+                        SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                        for namespaced resources defined in this KustomizationRef.
+                        This field is ignored for cluster-scoped resources.
+                        By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                        Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                        permissions to manage namespaces at the cluster level.
+                      type: boolean
                     targetNamespace:
                       description: |-
                         TargetNamespace sets or overrides the namespace in the
@@ -1072,6 +1092,16 @@ spec:
                         Defaults to 'None', which translates to the root path of the SourceRef.
                         Used only for GitRepository;OCIRepository;Bucket
                       type: string
+                    skipNamespaceCreation:
+                      default: false
+                      description: |-
+                        SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                        for namespaced resources defined in this PolicyRef.
+                        This field is ignored for cluster-scoped resources.
+                        By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                        Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                        permissions to manage namespaces at the cluster level.
+                      type: boolean
                     tier:
                       default: 100
                       description: |-

--- a/charts/crds/templates/profile-crd.yaml
+++ b/charts/crds/templates/profile-crd.yaml
@@ -338,6 +338,16 @@ spec:
                           description: PassCredentialsAll is the flag to pass credentials
                             to all domains
                           type: boolean
+                        runTests:
+                          default: false
+                          description: |-
+                            RunTests if set to true, Sveltos will run helm test after each successful install or upgrade
+                            operation. The tests are the test hooks defined in the chart (annotated with
+                            "helm.sh/hook: test"). If any test fails the deployment is considered failed and the
+                            error is surfaced in the ClusterSummary status, providing operational gating.
+                            Has no effect in DryRun mode.
+                            Default to false
+                          type: boolean
                         skipCRDs:
                           default: false
                           description: |-
@@ -705,6 +715,16 @@ spec:
                         When expressed as templates, the values are filled in using information from
                         resources within the management cluster before deployment (Cluster)
                       type: string
+                    skipNamespaceCreation:
+                      default: false
+                      description: |-
+                        SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                        for namespaced resources defined in this KustomizationRef.
+                        This field is ignored for cluster-scoped resources.
+                        By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                        Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                        permissions to manage namespaces at the cluster level.
+                      type: boolean
                     targetNamespace:
                       description: |-
                         TargetNamespace sets or overrides the namespace in the
@@ -989,6 +1009,16 @@ spec:
                         Defaults to 'None', which translates to the root path of the SourceRef.
                         Used only for GitRepository;OCIRepository;Bucket
                       type: string
+                    skipNamespaceCreation:
+                      default: false
+                      description: |-
+                        SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                        for namespaced resources defined in this PolicyRef.
+                        This field is ignored for cluster-scoped resources.
+                        By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                        Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                        permissions to manage namespaces at the cluster level.
+                      type: boolean
                     tier:
                       default: 100
                       description: |-

--- a/charts/crds/templates/sveltoscluster-crd.yaml
+++ b/charts/crds/templates/sveltoscluster-crd.yaml
@@ -452,6 +452,14 @@ spec:
                 description: TokenRequestRenewalOption contains options describing how
                   to renew TokenRequest
                 properties:
+                  kubeconfigKeyName:
+                    description: |-
+                      KubeconfigKeyName is the name of the key in the Secret where the renewed
+                      kubeconfig will be stored.
+                      If nil, Sveltos defaults to "re-kubeconfig" and updates SveltosCluster.Spec.KubeconfigKeyName.
+                      If set, Sveltos writes to this key. To prevent GitOps drift, set this to the
+                      same value as SveltosCluster.Spec.KubeconfigKeyName.
+                    type: string
                   renewTokenRequestInterval:
                     description: RenewTokenRequestInterval is the interval at which
                       to renew the TokenRequest

--- a/charts/dashboard/Chart.yaml
+++ b/charts/dashboard/Chart.yaml
@@ -14,10 +14,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.0
+version: 1.8.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.7.0"
+appVersion: "1.8.0"
 icon: https://github.com/projectsveltos/sveltos/raw/main/docs/assets/logo.png

--- a/charts/dashboard/README.md
+++ b/charts/dashboard/README.md
@@ -1,6 +1,6 @@
 # sveltos-dashboard
 
-![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
+![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
 
 A Helm chart for Sveltos dashboard
 
@@ -13,8 +13,8 @@ A Helm chart for Sveltos dashboard
 | global.imagePullSecrets | list | `[]` |  |
 | dashboard.annotations | object | `{}` |  |
 | dashboard.dashboard.image.repository | string | `"projectsveltos/dashboard"` |  |
-| dashboard.dashboard.image.tag | string | `"v1.7.0"` |  |
-| dashboard.dashboard.image.digest | string | `"sha256:c8fb4cee3f5e9010cac40ac936cf0187682a3afc6fa9689b6629bc300681a5f4"` |  |
+| dashboard.dashboard.image.tag | string | `"v1.8.0"` |  |
+| dashboard.dashboard.image.digest | string | `"sha256:a8f225e99373e3365fd4d4fb70d0f0d6e2cf9f8102ee627f2d2d8de1f37f6dba"` |  |
 | dashboard.dashboard.resources.limits.cpu | string | `"500m"` |  |
 | dashboard.dashboard.resources.limits.memory | string | `"512Mi"` |  |
 | dashboard.dashboard.resources.requests.cpu | string | `"100m"` |  |
@@ -47,8 +47,8 @@ A Helm chart for Sveltos dashboard
 | uiBackendManager.manager.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | uiBackendManager.manager.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | uiBackendManager.manager.image.repository | string | `"projectsveltos/ui-backend"` |  |
-| uiBackendManager.manager.image.tag | string | `"v1.7.0"` |  |
-| uiBackendManager.manager.image.digest | string | `"sha256:8f37d58956a6240737dc06e7dba63410006d2ceae4b2ad2aa98338d3929f4845"` |  |
+| uiBackendManager.manager.image.tag | string | `"v1.8.0"` |  |
+| uiBackendManager.manager.image.digest | string | `"sha256:10def0e50c110575a61eda1747ae69f86a50f516b77651c19b6d30855799c86f"` |  |
 | uiBackendManager.manager.resources.limits.cpu | string | `"500m"` |  |
 | uiBackendManager.manager.resources.limits.memory | string | `"512Mi"` |  |
 | uiBackendManager.manager.resources.requests.cpu | string | `"100m"` |  |

--- a/charts/dashboard/values.yaml
+++ b/charts/dashboard/values.yaml
@@ -7,8 +7,8 @@ dashboard:
   dashboard:
     image:
       repository: projectsveltos/dashboard
-      tag: v1.7.0
-      digest: sha256:c8fb4cee3f5e9010cac40ac936cf0187682a3afc6fa9689b6629bc300681a5f4
+      tag: v1.8.0
+      digest: sha256:a8f225e99373e3365fd4d4fb70d0f0d6e2cf9f8102ee627f2d2d8de1f37f6dba
     resources:
       limits:
         cpu: 500m
@@ -83,8 +83,8 @@ uiBackendManager:
           - ALL
     image:
       repository: projectsveltos/ui-backend
-      tag: v1.7.0
-      digest: sha256:8f37d58956a6240737dc06e7dba63410006d2ceae4b2ad2aa98338d3929f4845
+      tag: v1.8.0
+      digest: sha256:10def0e50c110575a61eda1747ae69f86a50f516b77651c19b6d30855799c86f
     resources:
       limits:
         cpu: 500m

--- a/charts/projectsveltos/Chart.yaml
+++ b/charts/projectsveltos/Chart.yaml
@@ -13,10 +13,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.0
+version: 1.8.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.7.0"
+appVersion: "1.8.0"
 icon: https://github.com/projectsveltos/sveltos/raw/main/docs/assets/logo.png

--- a/charts/projectsveltos/README.md
+++ b/charts/projectsveltos/README.md
@@ -1,6 +1,6 @@
 # projectsveltos
 
-![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
+![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
 
 Projectsveltos helm chart for Kubernetes
 
@@ -24,8 +24,8 @@ Projectsveltos helm chart for Kubernetes
 | accessManager.manager.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | accessManager.manager.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | accessManager.manager.image.repository | string | `"projectsveltos/access-manager"` |  |
-| accessManager.manager.image.tag | string | `"v1.7.0"` |  |
-| accessManager.manager.image.digest | string | `"sha256:287997687026316a126c540f514b0d5f7e0820ac9dcac9290613b230594e9754"` |  |
+| accessManager.manager.image.tag | string | `"v1.8.0"` |  |
+| accessManager.manager.image.digest | string | `"sha256:85160add21344f3e445b1e9e552554c5f7118b4e47c4a6148cebba5a0a10f473"` |  |
 | accessManager.manager.resources.limits.cpu | string | `"500m"` |  |
 | accessManager.manager.resources.limits.memory | string | `"512Mi"` |  |
 | accessManager.manager.resources.requests.cpu | string | `"10m"` |  |
@@ -37,8 +37,8 @@ Projectsveltos helm chart for Kubernetes
 | addonController.annotations | object | `{}` |  |
 | addonController.labels | object | `{}` |  |
 | addonController.initialization.image.repository | string | `"projectsveltos/addon-controller"` |  |
-| addonController.initialization.image.tag | string | `"v1.7.0"` |  |
-| addonController.initialization.image.digest | string | `"sha256:eba2d3408b93db1d37f1ecae5238254c911cf1fac3a564ea49a0b505695f27a2"` |  |
+| addonController.initialization.image.tag | string | `"v1.8.0"` |  |
+| addonController.initialization.image.digest | string | `"sha256:7250b8445fa0d353baaccaa51705da794a9c75760dcd746afe595ca4bb387218"` |  |
 | addonController.initialization.resources.limits.cpu | string | `"500m"` |  |
 | addonController.initialization.resources.limits.memory | string | `"512Mi"` |  |
 | addonController.initialization.resources.requests.cpu | string | `"10m"` |  |
@@ -47,13 +47,13 @@ Projectsveltos helm chart for Kubernetes
 | addonController.controller.args[1] | string | `"--report-mode=0"` |  |
 | addonController.controller.args[2] | string | `"--shard-key="` |  |
 | addonController.controller.args[3] | string | `"--v=5"` |  |
-| addonController.controller.args[4] | string | `"--version=v1.7.0"` |  |
+| addonController.controller.args[4] | string | `"--version=v1.8.0"` |  |
 | addonController.controller.extraArgs | object | `{}` |  |
 | addonController.controller.argsAgentMgmtCluster[0] | string | `"--diagnostics-address=:8443"` |  |
 | addonController.controller.argsAgentMgmtCluster[1] | string | `"--report-mode=0"` |  |
 | addonController.controller.argsAgentMgmtCluster[2] | string | `"--shard-key="` |  |
 | addonController.controller.argsAgentMgmtCluster[3] | string | `"--v=5"` |  |
-| addonController.controller.argsAgentMgmtCluster[4] | string | `"--version=v1.7.0"` |  |
+| addonController.controller.argsAgentMgmtCluster[4] | string | `"--version=v1.8.0"` |  |
 | addonController.controller.argsAgentMgmtCluster[5] | string | `"--agent-in-mgmt-cluster=true"` |  |
 | addonController.controller.extraArgsAgentMgmtCluster | object | `{}` |  |
 | addonController.controller.extraEnv | list | `[]` |  |
@@ -61,8 +61,8 @@ Projectsveltos helm chart for Kubernetes
 | addonController.controller.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | addonController.controller.containerSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | addonController.controller.image.repository | string | `"projectsveltos/addon-controller"` |  |
-| addonController.controller.image.tag | string | `"v1.7.0"` |  |
-| addonController.controller.image.digest | string | `"sha256:eba2d3408b93db1d37f1ecae5238254c911cf1fac3a564ea49a0b505695f27a2"` |  |
+| addonController.controller.image.tag | string | `"v1.8.0"` |  |
+| addonController.controller.image.digest | string | `"sha256:7250b8445fa0d353baaccaa51705da794a9c75760dcd746afe595ca4bb387218"` |  |
 | addonController.controller.resources.requests.memory | string | `"512Mi"` |  |
 | addonController.driftDetectionManagerPatchConfigMap.name | string | `"drift-detection-config"` |  |
 | addonController.driftDetectionManagerPatchConfigMap.data | object | `{}` |  |
@@ -92,21 +92,21 @@ Projectsveltos helm chart for Kubernetes
 | classifierManager.manager.args[1] | string | `"--report-mode=0"` |  |
 | classifierManager.manager.args[2] | string | `"--shard-key="` |  |
 | classifierManager.manager.args[3] | string | `"--v=5"` |  |
-| classifierManager.manager.args[4] | string | `"--version=v1.7.0"` |  |
+| classifierManager.manager.args[4] | string | `"--version=v1.8.0"` |  |
 | classifierManager.manager.extraArgs | object | `{}` |  |
 | classifierManager.manager.argsAgentMgmtCluster[0] | string | `"--diagnostics-address=:8443"` |  |
 | classifierManager.manager.argsAgentMgmtCluster[1] | string | `"--report-mode=0"` |  |
 | classifierManager.manager.argsAgentMgmtCluster[2] | string | `"--shard-key="` |  |
 | classifierManager.manager.argsAgentMgmtCluster[3] | string | `"--v=5"` |  |
-| classifierManager.manager.argsAgentMgmtCluster[4] | string | `"--version=v1.7.0"` |  |
+| classifierManager.manager.argsAgentMgmtCluster[4] | string | `"--version=v1.8.0"` |  |
 | classifierManager.manager.argsAgentMgmtCluster[5] | string | `"--agent-in-mgmt-cluster=true"` |  |
 | classifierManager.manager.extraArgsAgentMgmtCluster | object | `{}` |  |
 | classifierManager.manager.extraEnv | list | `[]` |  |
 | classifierManager.manager.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | classifierManager.manager.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | classifierManager.manager.image.repository | string | `"projectsveltos/classifier"` |  |
-| classifierManager.manager.image.tag | string | `"v1.7.0"` |  |
-| classifierManager.manager.image.digest | string | `"sha256:eaaf95d84f75699cd727f6a0b206d5ca5d4ce5a5da844bfd1886d524acbd9261"` |  |
+| classifierManager.manager.image.tag | string | `"v1.8.0"` |  |
+| classifierManager.manager.image.digest | string | `"sha256:8f5307fbdab235378276afaa6316639ec91a70590d09e8b2abaf4c3ab1708fb2"` |  |
 | classifierManager.manager.resources.limits.cpu | string | `"500m"` |  |
 | classifierManager.manager.resources.limits.memory | string | `"512Mi"` |  |
 | classifierManager.manager.resources.requests.cpu | string | `"100m"` |  |
@@ -121,20 +121,20 @@ Projectsveltos helm chart for Kubernetes
 | eventManager.manager.args[0] | string | `"--diagnostics-address=:8443"` |  |
 | eventManager.manager.args[1] | string | `"--shard-key="` |  |
 | eventManager.manager.args[2] | string | `"--v=5"` |  |
-| eventManager.manager.args[3] | string | `"--version=v1.7.0"` |  |
+| eventManager.manager.args[3] | string | `"--version=v1.8.0"` |  |
 | eventManager.manager.extraArgs | object | `{}` |  |
 | eventManager.manager.argsAgentMgmtCluster[0] | string | `"--diagnostics-address=:8443"` |  |
 | eventManager.manager.argsAgentMgmtCluster[1] | string | `"--shard-key="` |  |
 | eventManager.manager.argsAgentMgmtCluster[2] | string | `"--v=5"` |  |
-| eventManager.manager.argsAgentMgmtCluster[3] | string | `"--version=v1.7.0"` |  |
+| eventManager.manager.argsAgentMgmtCluster[3] | string | `"--version=v1.8.0"` |  |
 | eventManager.manager.argsAgentMgmtCluster[4] | string | `"--agent-in-mgmt-cluster=true"` |  |
 | eventManager.manager.extraArgsAgentMgmtCluster | object | `{}` |  |
 | eventManager.manager.extraEnv | list | `[]` |  |
 | eventManager.manager.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | eventManager.manager.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | eventManager.manager.image.repository | string | `"projectsveltos/event-manager"` |  |
-| eventManager.manager.image.tag | string | `"v1.7.0"` |  |
-| eventManager.manager.image.digest | string | `"sha256:6d8a13773841e008f5aea7dcb468a774a400b1e8c25e6a98c6576b46334d9127"` |  |
+| eventManager.manager.image.tag | string | `"v1.8.0"` |  |
+| eventManager.manager.image.digest | string | `"sha256:cb059369dd877df9510386c25dcb1b6f3b1633deda3124e7a2dbcfe81d34be1c"` |  |
 | eventManager.manager.resources.limits.cpu | string | `"500m"` |  |
 | eventManager.manager.resources.limits.memory | string | `"512Mi"` |  |
 | eventManager.manager.resources.requests.cpu | string | `"10m"` |  |
@@ -148,20 +148,20 @@ Projectsveltos helm chart for Kubernetes
 | hcManager.manager.args[0] | string | `"--diagnostics-address=:8443"` |  |
 | hcManager.manager.args[1] | string | `"--shard-key="` |  |
 | hcManager.manager.args[2] | string | `"--v=5"` |  |
-| hcManager.manager.args[3] | string | `"--version=v1.7.0"` |  |
+| hcManager.manager.args[3] | string | `"--version=v1.8.0"` |  |
 | hcManager.manager.extraArgs | object | `{}` |  |
 | hcManager.manager.argsAgentMgmtCluster[0] | string | `"--diagnostics-address=:8443"` |  |
 | hcManager.manager.argsAgentMgmtCluster[1] | string | `"--shard-key="` |  |
 | hcManager.manager.argsAgentMgmtCluster[2] | string | `"--v=5"` |  |
-| hcManager.manager.argsAgentMgmtCluster[3] | string | `"--version=v1.7.0"` |  |
+| hcManager.manager.argsAgentMgmtCluster[3] | string | `"--version=v1.8.0"` |  |
 | hcManager.manager.argsAgentMgmtCluster[4] | string | `"--agent-in-mgmt-cluster=true"` |  |
 | hcManager.manager.extraArgsAgentMgmtCluster | object | `{}` |  |
 | hcManager.manager.extraEnv | list | `[]` |  |
 | hcManager.manager.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | hcManager.manager.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | hcManager.manager.image.repository | string | `"projectsveltos/healthcheck-manager"` |  |
-| hcManager.manager.image.tag | string | `"v1.7.0"` |  |
-| hcManager.manager.image.digest | string | `"sha256:33891e8c2edb6dfc50fcc8b7396cb1672c2e9cd67666a52bc0b56e0dc18f7b43"` |  |
+| hcManager.manager.image.tag | string | `"v1.8.0"` |  |
+| hcManager.manager.image.digest | string | `"sha256:a64a210ee6464542019c820425d4979d2ee1ae5f461221528e30191eddef1105"` |  |
 | hcManager.manager.resources.limits.cpu | string | `"500m"` |  |
 | hcManager.manager.resources.limits.memory | string | `"512Mi"` |  |
 | hcManager.manager.resources.requests.cpu | string | `"10m"` |  |
@@ -176,8 +176,8 @@ Projectsveltos helm chart for Kubernetes
 | crdManagerJob.crdManager.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | crdManagerJob.crdManager.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | crdManagerJob.crdManager.image.repository | string | `"projectsveltos/crd-manager"` |  |
-| crdManagerJob.crdManager.image.tag | string | `"v1.7.0"` |  |
-| crdManagerJob.crdManager.image.digest | string | `"sha256:df724b71febb7218a3cee1dead4600b360f480c71816981b2dfb626ed205b86e"` |  |
+| crdManagerJob.crdManager.image.tag | string | `"v1.8.0"` |  |
+| crdManagerJob.crdManager.image.digest | string | `"sha256:9ae979476da0b6f63d8441e49b337452ded7c45138d1738377c8f1b9ad4e903b"` |  |
 | crdManagerJob.crdManager.imagePullPolicy | string | `"IfNotPresent"` |  |
 | crdManagerJob.crdManager.nodeSelector | object | `{}` |  |
 | crdManagerJob.crdManager.tolerations | list | `[]` |  |
@@ -192,8 +192,8 @@ Projectsveltos helm chart for Kubernetes
 | registerMgmtClusterJob.registerMgmtCluster.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | registerMgmtClusterJob.registerMgmtCluster.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | registerMgmtClusterJob.registerMgmtCluster.image.repository | string | `"projectsveltos/register-mgmt-cluster"` |  |
-| registerMgmtClusterJob.registerMgmtCluster.image.tag | string | `"v1.7.0"` |  |
-| registerMgmtClusterJob.registerMgmtCluster.image.digest | string | `"sha256:072ec92cf5cb09e32fd2e0718fd28098514a6bbdb92a0461c53998a218419514"` |  |
+| registerMgmtClusterJob.registerMgmtCluster.image.tag | string | `"v1.8.0"` |  |
+| registerMgmtClusterJob.registerMgmtCluster.image.digest | string | `"sha256:7f8cff59f344118cfb92a572bf9ab8f1dbb6a274c767c0351c2a814345e6e4a0"` |  |
 | registerMgmtClusterJob.registerMgmtCluster.imagePullPolicy | string | `"IfNotPresent"` |  |
 | registerMgmtClusterJob.registerMgmtCluster.nodeSelector | object | `{}` |  |
 | registerMgmtClusterJob.registerMgmtCluster.tolerations | list | `[]` |  |
@@ -208,8 +208,8 @@ Projectsveltos helm chart for Kubernetes
 | scManager.manager.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | scManager.manager.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | scManager.manager.image.repository | string | `"projectsveltos/sveltoscluster-manager"` |  |
-| scManager.manager.image.tag | string | `"v1.7.0"` |  |
-| scManager.manager.image.digest | string | `"sha256:d4ed6f926bc9954fc7175d643df431e78de34384cb19c2300270903f0ddfaa04"` |  |
+| scManager.manager.image.tag | string | `"v1.8.0"` |  |
+| scManager.manager.image.digest | string | `"sha256:363f40c413836e544e08c34b8dcf61ae289dced621b0811a6ddb100269b1b9fa"` |  |
 | scManager.manager.resources.limits.cpu | string | `"500m"` |  |
 | scManager.manager.resources.limits.memory | string | `"512Mi"` |  |
 | scManager.manager.resources.requests.cpu | string | `"10m"` |  |
@@ -240,8 +240,8 @@ Projectsveltos helm chart for Kubernetes
 | shardController.manager.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | shardController.manager.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | shardController.manager.image.repository | string | `"projectsveltos/shard-controller"` |  |
-| shardController.manager.image.tag | string | `"v1.7.0"` |  |
-| shardController.manager.image.digest | string | `"sha256:e27b3973f488296b6f6e3931463d0b8081bb392e77934a431d12c2e17b4b0f54"` |  |
+| shardController.manager.image.tag | string | `"v1.8.0"` |  |
+| shardController.manager.image.digest | string | `"sha256:d505673e72b9a76555b8d6acd4929a4440e64682c3514525a0650f9119e92d47"` |  |
 | shardController.manager.resources.limits.cpu | string | `"500m"` |  |
 | shardController.manager.resources.limits.memory | string | `"512Mi"` |  |
 | shardController.manager.resources.requests.cpu | string | `"10m"` |  |
@@ -260,8 +260,8 @@ Projectsveltos helm chart for Kubernetes
 | techsupportController.controller.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | techsupportController.controller.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | techsupportController.controller.image.repository | string | `"projectsveltos/techsupport"` |  |
-| techsupportController.controller.image.tag | string | `"v1.7.0"` |  |
-| techsupportController.controller.image.digest | string | `"sha256:c23c546c0d210e9aa8580f790523b8c0f55c9e62871f9d56a63ff69f06b1e24f"` |  |
+| techsupportController.controller.image.tag | string | `"v1.8.0"` |  |
+| techsupportController.controller.image.digest | string | `"sha256:e15055d90a3667f13ebc9ea7b977177c5ad0d4924327c0677c8e823e5b0c0122"` |  |
 | techsupportController.controller.resources.limits.cpu | string | `"500m"` |  |
 | techsupportController.controller.resources.limits.memory | string | `"1024Mi"` |  |
 | techsupportController.controller.resources.requests.cpu | string | `"10m"` |  |
@@ -280,8 +280,8 @@ Projectsveltos helm chart for Kubernetes
 | mcpServer.controller.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | mcpServer.controller.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | mcpServer.controller.image.repository | string | `"projectsveltos/mcp-server"` |  |
-| mcpServer.controller.image.tag | string | `"v1.7.0"` |  |
-| mcpServer.controller.image.digest | string | `"sha256:3e208bef095920194f22431f382eeafa6a9c42ed8cb5018b3da186a7cf837992"` |  |
+| mcpServer.controller.image.tag | string | `"v1.8.0"` |  |
+| mcpServer.controller.image.digest | string | `"sha256:ae870901adca13537003967ff42c0b666bb37dbec7918a7990a3bb84ecdf38ad"` |  |
 | mcpServer.controller.resources.limits.cpu | string | `"500m"` |  |
 | mcpServer.controller.resources.limits.memory | string | `"1024Mi"` |  |
 | mcpServer.controller.resources.requests.cpu | string | `"100m"` |  |

--- a/charts/projectsveltos/crds/clusterprofile-crd.yaml
+++ b/charts/projectsveltos/crds/clusterprofile-crd.yaml
@@ -338,6 +338,16 @@ spec:
                           description: PassCredentialsAll is the flag to pass credentials
                             to all domains
                           type: boolean
+                        runTests:
+                          default: false
+                          description: |-
+                            RunTests if set to true, Sveltos will run helm test after each successful install or upgrade
+                            operation. The tests are the test hooks defined in the chart (annotated with
+                            "helm.sh/hook: test"). If any test fails the deployment is considered failed and the
+                            error is surfaced in the ClusterSummary status, providing operational gating.
+                            Has no effect in DryRun mode.
+                            Default to false
+                          type: boolean
                         skipCRDs:
                           default: false
                           description: |-
@@ -706,6 +716,16 @@ spec:
                         When expressed as templates, the values are filled in using information from
                         resources within the management cluster before deployment (Cluster)
                       type: string
+                    skipNamespaceCreation:
+                      default: false
+                      description: |-
+                        SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                        for namespaced resources defined in this KustomizationRef.
+                        This field is ignored for cluster-scoped resources.
+                        By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                        Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                        permissions to manage namespaces at the cluster level.
+                      type: boolean
                     targetNamespace:
                       description: |-
                         TargetNamespace sets or overrides the namespace in the
@@ -990,6 +1010,16 @@ spec:
                         Defaults to 'None', which translates to the root path of the SourceRef.
                         Used only for GitRepository;OCIRepository;Bucket
                       type: string
+                    skipNamespaceCreation:
+                      default: false
+                      description: |-
+                        SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                        for namespaced resources defined in this PolicyRef.
+                        This field is ignored for cluster-scoped resources.
+                        By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                        Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                        permissions to manage namespaces at the cluster level.
+                      type: boolean
                     tier:
                       default: 100
                       description: |-

--- a/charts/projectsveltos/crds/clusterpromotion-crd.yaml
+++ b/charts/projectsveltos/crds/clusterpromotion-crd.yaml
@@ -238,6 +238,16 @@ spec:
                               description: PassCredentialsAll is the flag to pass
                                 credentials to all domains
                               type: boolean
+                            runTests:
+                              default: false
+                              description: |-
+                                RunTests if set to true, Sveltos will run helm test after each successful install or upgrade
+                                operation. The tests are the test hooks defined in the chart (annotated with
+                                "helm.sh/hook: test"). If any test fails the deployment is considered failed and the
+                                error is surfaced in the ClusterSummary status, providing operational gating.
+                                Has no effect in DryRun mode.
+                                Default to false
+                              type: boolean
                             skipCRDs:
                               default: false
                               description: |-
@@ -607,6 +617,16 @@ spec:
                             When expressed as templates, the values are filled in using information from
                             resources within the management cluster before deployment (Cluster)
                           type: string
+                        skipNamespaceCreation:
+                          default: false
+                          description: |-
+                            SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                            for namespaced resources defined in this KustomizationRef.
+                            This field is ignored for cluster-scoped resources.
+                            By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                            Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                            permissions to manage namespaces at the cluster level.
+                          type: boolean
                         targetNamespace:
                           description: |-
                             TargetNamespace sets or overrides the namespace in the
@@ -891,6 +911,16 @@ spec:
                             Defaults to 'None', which translates to the root path of the SourceRef.
                             Used only for GitRepository;OCIRepository;Bucket
                           type: string
+                        skipNamespaceCreation:
+                          default: false
+                          description: |-
+                            SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                            for namespaced resources defined in this PolicyRef.
+                            This field is ignored for cluster-scoped resources.
+                            By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                            Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                            permissions to manage namespaces at the cluster level.
+                          type: boolean
                         tier:
                           default: 100
                           description: |-
@@ -1612,6 +1642,16 @@ spec:
                                       Defaults to 'None', which translates to the root path of the SourceRef.
                                       Used only for GitRepository;OCIRepository;Bucket
                                     type: string
+                                  skipNamespaceCreation:
+                                    default: false
+                                    description: |-
+                                      SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                                      for namespaced resources defined in this PolicyRef.
+                                      This field is ignored for cluster-scoped resources.
+                                      By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                                      Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                                      permissions to manage namespaces at the cluster level.
+                                    type: boolean
                                   tier:
                                     default: 100
                                     description: |-
@@ -1843,6 +1883,16 @@ spec:
                                       Defaults to 'None', which translates to the root path of the SourceRef.
                                       Used only for GitRepository;OCIRepository;Bucket
                                     type: string
+                                  skipNamespaceCreation:
+                                    default: false
+                                    description: |-
+                                      SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                                      for namespaced resources defined in this PolicyRef.
+                                      This field is ignored for cluster-scoped resources.
+                                      By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                                      Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                                      permissions to manage namespaces at the cluster level.
+                                    type: boolean
                                   tier:
                                     default: 100
                                     description: |-

--- a/charts/projectsveltos/crds/clustersummary-crd.yaml
+++ b/charts/projectsveltos/crds/clustersummary-crd.yaml
@@ -375,6 +375,16 @@ spec:
                               description: PassCredentialsAll is the flag to pass
                                 credentials to all domains
                               type: boolean
+                            runTests:
+                              default: false
+                              description: |-
+                                RunTests if set to true, Sveltos will run helm test after each successful install or upgrade
+                                operation. The tests are the test hooks defined in the chart (annotated with
+                                "helm.sh/hook: test"). If any test fails the deployment is considered failed and the
+                                error is surfaced in the ClusterSummary status, providing operational gating.
+                                Has no effect in DryRun mode.
+                                Default to false
+                              type: boolean
                             skipCRDs:
                               default: false
                               description: |-
@@ -744,6 +754,16 @@ spec:
                             When expressed as templates, the values are filled in using information from
                             resources within the management cluster before deployment (Cluster)
                           type: string
+                        skipNamespaceCreation:
+                          default: false
+                          description: |-
+                            SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                            for namespaced resources defined in this KustomizationRef.
+                            This field is ignored for cluster-scoped resources.
+                            By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                            Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                            permissions to manage namespaces at the cluster level.
+                          type: boolean
                         targetNamespace:
                           description: |-
                             TargetNamespace sets or overrides the namespace in the
@@ -1028,6 +1048,16 @@ spec:
                             Defaults to 'None', which translates to the root path of the SourceRef.
                             Used only for GitRepository;OCIRepository;Bucket
                           type: string
+                        skipNamespaceCreation:
+                          default: false
+                          description: |-
+                            SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                            for namespaced resources defined in this PolicyRef.
+                            This field is ignored for cluster-scoped resources.
+                            By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                            Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                            permissions to manage namespaces at the cluster level.
+                          type: boolean
                         tier:
                           default: 100
                           description: |-
@@ -1652,6 +1682,11 @@ spec:
                     failureMessage:
                       description: FailureMessage provides the specific error from
                         the Helm engine for this release
+                      type: string
+                    patchesHash:
+                      description: PatchesHash represents of a unique value for the
+                        patches section
+                      format: byte
                       type: string
                     releaseName:
                       description: ReleaseName is the chart release

--- a/charts/projectsveltos/crds/configurationbundle-crd.yaml
+++ b/charts/projectsveltos/crds/configurationbundle-crd.yaml
@@ -115,6 +115,16 @@ spec:
                   type: string
                 type: array
                 x-kubernetes-list-type: atomic
+              skipNamespaceCreation:
+                default: false
+                description: |-
+                  SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                  for namespaced resources defined in this PolicyRef.
+                  This field is ignored for cluster-scoped resources.
+                  By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                  Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                  permissions to manage namespaces at the cluster level.
+                type: boolean
               timeout:
                 description: time to wait for Kubernetes operation (like Jobs for
                   hooks)

--- a/charts/projectsveltos/crds/eventtrigger-crd.yaml
+++ b/charts/projectsveltos/crds/eventtrigger-crd.yaml
@@ -413,6 +413,16 @@ spec:
                           description: PassCredentialsAll is the flag to pass credentials
                             to all domains
                           type: boolean
+                        runTests:
+                          default: false
+                          description: |-
+                            RunTests if set to true, Sveltos will run helm test after each successful install or upgrade
+                            operation. The tests are the test hooks defined in the chart (annotated with
+                            "helm.sh/hook: test"). If any test fails the deployment is considered failed and the
+                            error is surfaced in the ClusterSummary status, providing operational gating.
+                            Has no effect in DryRun mode.
+                            Default to false
+                          type: boolean
                         skipCRDs:
                           default: false
                           description: |-
@@ -782,6 +792,16 @@ spec:
                         When expressed as templates, the values are filled in using information from
                         resources within the management cluster before deployment (Cluster)
                       type: string
+                    skipNamespaceCreation:
+                      default: false
+                      description: |-
+                        SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                        for namespaced resources defined in this KustomizationRef.
+                        This field is ignored for cluster-scoped resources.
+                        By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                        Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                        permissions to manage namespaces at the cluster level.
+                      type: boolean
                     targetNamespace:
                       description: |-
                         TargetNamespace sets or overrides the namespace in the
@@ -1072,6 +1092,16 @@ spec:
                         Defaults to 'None', which translates to the root path of the SourceRef.
                         Used only for GitRepository;OCIRepository;Bucket
                       type: string
+                    skipNamespaceCreation:
+                      default: false
+                      description: |-
+                        SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                        for namespaced resources defined in this PolicyRef.
+                        This field is ignored for cluster-scoped resources.
+                        By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                        Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                        permissions to manage namespaces at the cluster level.
+                      type: boolean
                     tier:
                       default: 100
                       description: |-

--- a/charts/projectsveltos/crds/profile-crd.yaml
+++ b/charts/projectsveltos/crds/profile-crd.yaml
@@ -338,6 +338,16 @@ spec:
                           description: PassCredentialsAll is the flag to pass credentials
                             to all domains
                           type: boolean
+                        runTests:
+                          default: false
+                          description: |-
+                            RunTests if set to true, Sveltos will run helm test after each successful install or upgrade
+                            operation. The tests are the test hooks defined in the chart (annotated with
+                            "helm.sh/hook: test"). If any test fails the deployment is considered failed and the
+                            error is surfaced in the ClusterSummary status, providing operational gating.
+                            Has no effect in DryRun mode.
+                            Default to false
+                          type: boolean
                         skipCRDs:
                           default: false
                           description: |-
@@ -706,6 +716,16 @@ spec:
                         When expressed as templates, the values are filled in using information from
                         resources within the management cluster before deployment (Cluster)
                       type: string
+                    skipNamespaceCreation:
+                      default: false
+                      description: |-
+                        SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                        for namespaced resources defined in this KustomizationRef.
+                        This field is ignored for cluster-scoped resources.
+                        By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                        Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                        permissions to manage namespaces at the cluster level.
+                      type: boolean
                     targetNamespace:
                       description: |-
                         TargetNamespace sets or overrides the namespace in the
@@ -990,6 +1010,16 @@ spec:
                         Defaults to 'None', which translates to the root path of the SourceRef.
                         Used only for GitRepository;OCIRepository;Bucket
                       type: string
+                    skipNamespaceCreation:
+                      default: false
+                      description: |-
+                        SkipNamespaceCreation indicates whether Sveltos should skip creating the namespace
+                        for namespaced resources defined in this PolicyRef.
+                        This field is ignored for cluster-scoped resources.
+                        By default, Sveltos attempts to get or create the target namespace if it does not exist.
+                        Setting this to true avoids those calls, which is necessary when Sveltos lacks
+                        permissions to manage namespaces at the cluster level.
+                      type: boolean
                     tier:
                       default: 100
                       description: |-

--- a/charts/projectsveltos/crds/sveltoscluster-crd.yaml
+++ b/charts/projectsveltos/crds/sveltoscluster-crd.yaml
@@ -452,6 +452,14 @@ spec:
                 description: TokenRequestRenewalOption contains options describing
                   how to renew TokenRequest
                 properties:
+                  kubeconfigKeyName:
+                    description: |-
+                      KubeconfigKeyName is the name of the key in the Secret where the renewed
+                      kubeconfig will be stored.
+                      If nil, Sveltos defaults to "re-kubeconfig" and updates SveltosCluster.Spec.KubeconfigKeyName.
+                      If set, Sveltos writes to this key. To prevent GitOps drift, set this to the
+                      same value as SveltosCluster.Spec.KubeconfigKeyName.
+                    type: string
                   renewTokenRequestInterval:
                     description: RenewTokenRequestInterval is the interval at which
                       to renew the TokenRequest

--- a/charts/projectsveltos/values.yaml
+++ b/charts/projectsveltos/values.yaml
@@ -23,8 +23,8 @@ accessManager:
           - ALL
     image:
       repository: projectsveltos/access-manager
-      tag: v1.7.0
-      digest: sha256:287997687026316a126c540f514b0d5f7e0820ac9dcac9290613b230594e9754
+      tag: v1.8.0
+      digest: sha256:85160add21344f3e445b1e9e552554c5f7118b4e47c4a6148cebba5a0a10f473
     resources:
       limits:
         cpu: 500m
@@ -44,8 +44,8 @@ addonController:
   initialization:
     image:
       repository: projectsveltos/addon-controller
-      tag: v1.7.0
-      digest: sha256:eba2d3408b93db1d37f1ecae5238254c911cf1fac3a564ea49a0b505695f27a2
+      tag: v1.8.0
+      digest: sha256:7250b8445fa0d353baaccaa51705da794a9c75760dcd746afe595ca4bb387218
     resources:
       limits:
         cpu: 500m
@@ -59,14 +59,14 @@ addonController:
       - --report-mode=0
       - --shard-key=
       - --v=5
-      - --version=v1.7.0
+      - --version=v1.8.0
     extraArgs: {}
     argsAgentMgmtCluster:
       - --diagnostics-address=:8443
       - --report-mode=0
       - --shard-key=
       - --v=5
-      - --version=v1.7.0
+      - --version=v1.8.0
       - --agent-in-mgmt-cluster=true
     extraArgsAgentMgmtCluster: {}
     extraEnv: []
@@ -79,8 +79,8 @@ addonController:
         type: RuntimeDefault
     image:
       repository: projectsveltos/addon-controller
-      tag: v1.7.0
-      digest: sha256:eba2d3408b93db1d37f1ecae5238254c911cf1fac3a564ea49a0b505695f27a2
+      tag: v1.8.0
+      digest: sha256:7250b8445fa0d353baaccaa51705da794a9c75760dcd746afe595ca4bb387218
     resources:
       requests:
         memory: 512Mi
@@ -127,14 +127,14 @@ classifierManager:
       - --report-mode=0
       - --shard-key=
       - --v=5
-      - --version=v1.7.0
+      - --version=v1.8.0
     extraArgs: {}
     argsAgentMgmtCluster:
       - --diagnostics-address=:8443
       - --report-mode=0
       - --shard-key=
       - --v=5
-      - --version=v1.7.0
+      - --version=v1.8.0
       - --agent-in-mgmt-cluster=true
     extraArgsAgentMgmtCluster: {}
     extraEnv: []
@@ -145,8 +145,8 @@ classifierManager:
           - ALL
     image:
       repository: projectsveltos/classifier
-      tag: v1.7.0
-      digest: sha256:eaaf95d84f75699cd727f6a0b206d5ca5d4ce5a5da844bfd1886d524acbd9261
+      tag: v1.8.0
+      digest: sha256:8f5307fbdab235378276afaa6316639ec91a70590d09e8b2abaf4c3ab1708fb2
     resources:
       limits:
         cpu: 500m
@@ -171,13 +171,13 @@ eventManager:
       - --diagnostics-address=:8443
       - --shard-key=
       - --v=5
-      - --version=v1.7.0
+      - --version=v1.8.0
     extraArgs: {}
     argsAgentMgmtCluster:
       - --diagnostics-address=:8443
       - --shard-key=
       - --v=5
-      - --version=v1.7.0
+      - --version=v1.8.0
       - --agent-in-mgmt-cluster=true
     extraArgsAgentMgmtCluster: {}
     extraEnv: []
@@ -188,8 +188,8 @@ eventManager:
           - ALL
     image:
       repository: projectsveltos/event-manager
-      tag: v1.7.0
-      digest: sha256:6d8a13773841e008f5aea7dcb468a774a400b1e8c25e6a98c6576b46334d9127
+      tag: v1.8.0
+      digest: sha256:cb059369dd877df9510386c25dcb1b6f3b1633deda3124e7a2dbcfe81d34be1c
     resources:
       limits:
         cpu: 500m
@@ -211,13 +211,13 @@ hcManager:
       - --diagnostics-address=:8443
       - --shard-key=
       - --v=5
-      - --version=v1.7.0
+      - --version=v1.8.0
     extraArgs: {}
     argsAgentMgmtCluster:
       - --diagnostics-address=:8443
       - --shard-key=
       - --v=5
-      - --version=v1.7.0
+      - --version=v1.8.0
       - --agent-in-mgmt-cluster=true
     extraArgsAgentMgmtCluster: {}
     extraEnv: []
@@ -228,8 +228,8 @@ hcManager:
           - ALL
     image:
       repository: projectsveltos/healthcheck-manager
-      tag: v1.7.0
-      digest: sha256:33891e8c2edb6dfc50fcc8b7396cb1672c2e9cd67666a52bc0b56e0dc18f7b43
+      tag: v1.8.0
+      digest: sha256:a64a210ee6464542019c820425d4979d2ee1ae5f461221528e30191eddef1105
     resources:
       limits:
         cpu: 500m
@@ -258,8 +258,8 @@ crdManagerJob:
         - ALL
     image:
       repository: projectsveltos/crd-manager
-      tag: v1.7.0
-      digest: sha256:df724b71febb7218a3cee1dead4600b360f480c71816981b2dfb626ed205b86e
+      tag: v1.8.0
+      digest: sha256:9ae979476da0b6f63d8441e49b337452ded7c45138d1738377c8f1b9ad4e903b
     imagePullPolicy: IfNotPresent
     nodeSelector: {}
     tolerations: []
@@ -285,8 +285,8 @@ registerMgmtClusterJob:
           - ALL
     image:
       repository: projectsveltos/register-mgmt-cluster
-      tag: v1.7.0
-      digest: sha256:072ec92cf5cb09e32fd2e0718fd28098514a6bbdb92a0461c53998a218419514
+      tag: v1.8.0
+      digest: sha256:7f8cff59f344118cfb92a572bf9ab8f1dbb6a274c767c0351c2a814345e6e4a0
     imagePullPolicy: IfNotPresent
     nodeSelector: {}
     tolerations: []
@@ -310,8 +310,8 @@ scManager:
           - ALL
     image:
       repository: projectsveltos/sveltoscluster-manager
-      tag: v1.7.0
-      digest: sha256:d4ed6f926bc9954fc7175d643df431e78de34384cb19c2300270903f0ddfaa04
+      tag: v1.8.0
+      digest: sha256:363f40c413836e544e08c34b8dcf61ae289dced621b0811a6ddb100269b1b9fa
     resources:
       limits:
         cpu: 500m
@@ -356,8 +356,8 @@ shardController:
           - ALL
     image:
       repository: projectsveltos/shard-controller
-      tag: v1.7.0
-      digest: sha256:e27b3973f488296b6f6e3931463d0b8081bb392e77934a431d12c2e17b4b0f54
+      tag: v1.8.0
+      digest: sha256:d505673e72b9a76555b8d6acd4929a4440e64682c3514525a0650f9119e92d47
     resources:
       limits:
         cpu: 500m
@@ -388,8 +388,8 @@ techsupportController:
           - ALL
     image:
       repository: projectsveltos/techsupport
-      tag: v1.7.0
-      digest: sha256:c23c546c0d210e9aa8580f790523b8c0f55c9e62871f9d56a63ff69f06b1e24f
+      tag: v1.8.0
+      digest: sha256:e15055d90a3667f13ebc9ea7b977177c5ad0d4924327c0677c8e823e5b0c0122
     resources:
       limits:
         cpu: 500m
@@ -421,8 +421,8 @@ mcpServer:
           - ALL
     image:
       repository: projectsveltos/mcp-server
-      tag: v1.7.0
-      digest: sha256:3e208bef095920194f22431f382eeafa6a9c42ed8cb5018b3da186a7cf837992
+      tag: v1.8.0
+      digest: sha256:ae870901adca13537003967ff42c0b666bb37dbec7918a7990a3bb84ecdf38ad
     resources:
       limits:
         cpu: 500m


### PR DESCRIPTION
## 🚀 New Features

**GitOps Friendly Kubeconfig Renewal**

Support for In-place Secret Updates: Previously, Sveltos rotated kubeconfigs by creating a new key (re-kubeconfig) and updating the SveltosCluster spec. This caused drift in GitOps tools like ArgoCD or Flux.

You can now define _spec.tokenRequestRenewalOption.kubeconfigKeyName_. If set to the original key name, Sveltos will overwrite the existing Secret in-place and skip updating the Spec, keeping your live state and Git source-of-truth in sync.

PR: [sveltoscluster-manager 361](https://github.com/projectsveltos/sveltoscluster-manager/pull/361)

**Enhanced Helm Testing**

Native Helm Tests: Introduced RunTests in the Helm configuration. When set to true, Sveltos will automatically run Helm test hooks (helm.sh/hook: test) after successful installs or upgrades.

Failing tests will surface as deployment failures in the ClusterSummary status, providing an automated operational gate.

PR: [addon-controller 1687](https://github.com/projectsveltos/addon-controller/pull/1687)

**Flexible Namespace Management**

Skip Namespace Creation: To support multi-tenant environments where Sveltos may have restricted RBAC (lacking cluster-wide Namespace permissions), we’ve introduced _SkipNamespaceCreation_ to PolicyRef and KustomizationRef.

When enabled, Sveltos bypasses the check/creation logic and attempts to deploy resources directly into pre-provisioned namespaces.

PR: [addon-controller 1685](https://github.com/projectsveltos/addon-controller/pull/1685)

## 🐞 Bug Fixes

**Helm & Patching Consistency**

- **Patch-Triggered Redeployments:** Fixed an issue where modifying Helm patches did not trigger a redeploy because the chart version and values remained unchanged. Sveltos now tracks a hash of the patches to accurately detect changes.

PR: [addon-controller 1686](https://github.com/projectsveltos/addon-controller/pull/1686)

- **Persistence of Failure Messages**: Resolved a sequencing bug where FailureMessage for Helm releases was being overwritten in the API server before it could be persisted.

PR: [addon-controller 1693](https://github.com/projectsveltos/addon-controller/pull/1693)

- **Template Resolution in Summaries**: Fixed a lookup failure where failure messages weren't being correctly mapped when ReleaseName or ReleaseNamespace contained Go templates.

PR: [addon-controller 1693](https://github.com/projectsveltos/addon-controller/pull/1693)

**Controller Robustness**

- **Out-of-band Deletions**: Fixed a reconciliation deadlock that occurred if a ClusterSummary was deleted manually while the cluster was in an UpdatingClusters state. The controller now recovers gracefully by dropping the cluster from the update list and forcing a requeue.

PR: [addon-controller 1704](https://github.com/projectsveltos/addon-controller/pull/1704)