### PR TITLE
Add additionalLabels for serviceMonitor resources

### DIFF
--- a/charts/projectsveltos/templates/addon-controller.yaml
+++ b/charts/projectsveltos/templates/addon-controller.yaml
@@ -20,6 +20,9 @@ metadata:
   name: addon-controller
   labels:
     control-plane: addon-controller
+  {{- with .Values.addonController.serviceMonitor.additionalLabels -}}
+    {{- toYaml . | nindent 4 -}}
+  {{- end -}}
   {{- include "projectsveltos.labels" . | nindent 4 }}
 spec:
   endpoints:

--- a/charts/projectsveltos/templates/sc-manager.yaml
+++ b/charts/projectsveltos/templates/sc-manager.yaml
@@ -19,7 +19,9 @@ kind: ServiceMonitor
 metadata:
   name: sc-manager
   labels:
-    release: prometheus-operator
+  {{- with .Values.scManager.serviceMonitor.additionalLabels -}}
+    {{- toYaml . | nindent 4 -}}
+  {{- end -}}
   {{- include "projectsveltos.labels" . | nindent 4 }}
 spec:
   endpoints:

--- a/charts/projectsveltos/values.yaml
+++ b/charts/projectsveltos/values.yaml
@@ -114,6 +114,8 @@ addonController:
           - update
   clusterRoleExtra:
     rules: null
+  serviceMonitor:
+    additionalLabels: {}
 classifierManager:
   annotations: {}
   labels: {}
@@ -340,6 +342,8 @@ scManager:
   serviceAccount:
     annotations: {}
   type: ClusterIP
+  serviceMonitor:
+    additionalLabels: {}
 shardController:
   enabled: true
   annotations: {}


### PR DESCRIPTION
It would be great to have the possibility to use whatever label is already is in use in the cluster, in order to discover the service monitor resources properly.

At the moment is not possible to set a label like "release: kube-prometheus-stack" because the same key is hardcoded in the template. 

Thanks!