### PR TITLE
rename OIDC auth env var names

### DIFF
--- a/charts/dashboard/Chart.yaml
+++ b/charts/dashboard/Chart.yaml
@@ -14,10 +14,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.10.0
+version: 1.10.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.10.0"
+appVersion: "1.10.1"
 icon: https://github.com/projectsveltos/sveltos/raw/main/docs/assets/logo.png

--- a/charts/dashboard/templates/deployment.yaml
+++ b/charts/dashboard/templates/deployment.yaml
@@ -117,12 +117,12 @@ spec:
         - name: VITE_APP_VERSION
           value: {{ .Values.dashboard.dashboard.image.tag }}
         {{- with ((.Values.auth).oidc) }}
-        - name: VITE_OIDC_ISSUER
+        - name: OIDC_ISSUER
           value: {{ .issuer | quote }}
-        - name: VITE_OIDC_CLIENT_ID
+        - name: OIDC_CLIENT_ID
           value: {{ .clientId | quote }}
         {{- if .redirectUri }}
-        - name: VITE_OIDC_REDIRECT_URI
+        - name: OIDC_REDIRECT_URI
           value: {{ .redirectUri | quote }}
         {{- end }}
         {{- end }}

--- a/charts/dashboard/values.yaml
+++ b/charts/dashboard/values.yaml
@@ -7,8 +7,8 @@ dashboard:
   dashboard:
     image:
       repository: projectsveltos/dashboard
-      tag: v1.10.0
-      digest: sha256:44ed73a47c2638f59733156519b916b8e039cacce350d001d5e73961d4e7007a
+      tag: v1.10.1
+      digest: sha256:0ed536770252846bbac024669a5836b666b25e765b80331471f9eb95716ca660
     resources:
       limits:
         cpu: 500m


### PR DESCRIPTION
Since these env vars should be dynamically imported at runtime, remove the `VITE_` prefix to avoid confusion with Vite build-time env vars.