### PR TITLE
Add shared configmap args to shard-controller

### DIFF
--- a/charts/projectsveltos/templates/deployment.yaml
+++ b/charts/projectsveltos/templates/deployment.yaml
@@ -813,6 +813,15 @@ spec:
         - --{{ $key }}
         {{- end }}
       {{- end }}
+  {{- if ne (len .Values.addonController.driftDetectionManagerPatchConfigMap.data) 0 }}
+        - --drift-detection-config={{ .Values.addonController.driftDetectionManagerPatchConfigMap.name }}
+  {{- end }}
+  {{- if ne (len .Values.classifierManager.agentPatchConfigMap.data) 0 }}
+        - --sveltos-agent-config={{ .Values.classifierManager.agentPatchConfigMap.name }}
+  {{- end }}
+  {{- if ne (len .Values.classifierManager.agentPatchSveltosApplierConfigMap.data) 0 }}
+        - --sveltos-applier-config={{ .Values.classifierManager.agentPatchSveltosApplierConfigMap.name }}
+  {{- end }}
   {{- else }}
       - args:
       {{- range .Values.shardController.manager.args }}
@@ -825,6 +834,15 @@ spec:
         - --{{ $key }}
         {{- end }}
       {{- end }}
+  {{- if ne (len .Values.addonController.driftDetectionManagerPatchConfigMap.data) 0 }}
+        - --drift-detection-config={{ .Values.addonController.driftDetectionManagerPatchConfigMap.name }}
+  {{- end }}
+  {{- if ne (len .Values.classifierManager.agentPatchConfigMap.data) 0 }}
+        - --sveltos-agent-config={{ .Values.classifierManager.agentPatchConfigMap.name }}
+  {{- end }}
+  {{- if ne (len .Values.classifierManager.agentPatchSveltosApplierConfigMap.data) 0 }}
+        - --sveltos-applier-config={{ .Values.classifierManager.agentPatchSveltosApplierConfigMap.name }}
+  {{- end }}
   {{- end }}
         command:
         - /manager


### PR DESCRIPTION
Enable shard-controller to use the same configuration options as addon-controller and classifier-manager by adding:
  - --drift-detection-config (from addonController)
  - --sveltos-agent-config (from classifierManager)
  - --sveltos-applier-config (from classifierManager)

This maintains consistency and allows the shard-controller to use and pass them on when creating shard level managed controllers (addon-controller and classifier).