### PR TITLE
feat: Add toggle to disable crd-manager

### DIFF
--- a/charts/projectsveltos/templates/crd-manager-job.yaml
+++ b/charts/projectsveltos/templates/crd-manager-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.crdManagerJob.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -52,3 +53,4 @@ spec:
       restartPolicy: OnFailure
       serviceAccountName: crd-manager
   ttlSecondsAfterFinished: 240
+{{- end }}

--- a/charts/projectsveltos/templates/crd-rbac.yaml
+++ b/charts/projectsveltos/templates/crd-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.crdManagerJob.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -39,3 +40,4 @@ subjects:
 - kind: ServiceAccount
   name: 'crd-manager'
   namespace: '{{ .Release.Namespace }}'
+{{- end }}

--- a/charts/projectsveltos/values.yaml
+++ b/charts/projectsveltos/values.yaml
@@ -276,6 +276,7 @@ crdManager:
       helm.sh/hook: pre-upgrade,pre-rollback
       helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
 crdManagerJob:
+  enabled: true
   backoffLimit: 4
   crdManager:
     extraEnv: []


### PR DESCRIPTION
Both [FluxCD](https://fluxcd.io/flux/components/helm/helmreleases/#controlling-the-lifecycle-of-custom-resource-definitions) and ArgoCD can manage CRDs from a helm chart mitigate Helm Upgrade CRD issues.

If Flux is used, no helm hook is necessary.