### PR TITLE
fix: grant classifier-manager namespaces get/list/watch (v1.12.0 migration RBAC)

### DIFF
--- a/charts/projectsveltos/Chart.yaml
+++ b/charts/projectsveltos/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.12.1
+version: 1.12.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/projectsveltos/templates/classifier-manager-rbac.yaml
+++ b/charts/projectsveltos/templates/classifier-manager-rbac.yaml
@@ -9,6 +9,7 @@ rules:
   - ""
   resources:
   - configmaps
+  - namespaces
   - secrets
   verbs:
   - get


### PR DESCRIPTION
The `classifier-manager` upgrade migration introduced in v1.12.0 fails on missing RBAC, crash-looping the `migrate` initContainer so `classifier-manager` never becomes Ready (its Deployment reports `ProgressDeadlineExceeded`).

### Symptom
```
main.go:291] "migration failed" err="migrating classifier default-classifier:
checking namespace <ns>: namespaces \"<ns>\" is forbidden:
User \"system:serviceaccount:projectsveltos:classifier-manager\" cannot get
resource \"namespaces\" in API group \"\" in the namespace \"<ns>\""
```

The migration `Get`s the namespace of each matching cluster (e.g. a management-cluster `SveltosCluster` registered in its own namespace when `agent.managementCluster=true`), but `classifier-manager-role` grants no `namespaces` verb. Any install that reaches the migration with a matching cluster gets stuck; the app stays Degraded.

### Fix
Add `namespaces` `get`/`list`/`watch` to the existing core (`""`) API-group rule in `classifier-manager-rbac.yaml`, and bump the chart version 1.12.1 → 1.12.2.

### Note for maintainers
This chart mirrors the controller RBAC. The durable fix is the corresponding kubebuilder marker in the `classifier` controller, e.g.:
```
// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
```
so a chart regen from `config/rbac/role.yaml` does not re-drop it. Happy to open that PR too.