### PR TITLE
fix: temporarily grant classifier-manager get/list/watch on namespaces

### DIFF
--- a/charts/projectsveltos/Chart.yaml
+++ b/charts/projectsveltos/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.12.1
+version: 1.12.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/projectsveltos/templates/classifier-manager-rbac.yaml
+++ b/charts/projectsveltos/templates/classifier-manager-rbac.yaml
@@ -42,6 +42,18 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+# TODO(remove): stopgap for projectsveltos/classifier#485 — the pre-fix migrate
+# initContainer Gets the Namespace of each migrated cluster entry. Drop this rule
+# once the fleet has moved to a classifier release containing the fix that checks
+# cluster existence instead (no longer needs "namespaces" get).
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - cluster.x-k8s.io
   resources:


### PR DESCRIPTION
Fixes the migrate initContainer crash-loop reported in [projectsveltos/classifier](https://github.com/projectsveltos/classifier/issues/485).

classifier's one-shot migration (added in v1.11.0, moving per-cluster status off Classifier.status and onto ClassifierReport.status) runs as an initContainer on every startup. For each stale/pending cluster entry it still finds in the deprecated status arrays, it does a Get on that cluster's Namespace.
classifier-manager-role has never granted get on core namespaces, so on any upgrade that still has real data in those deprecated arrays (i.e. going from pre-v1.11.0 straight to a current release, skipping the intermediate versions that already ran the migration once), the initContainer fails. And classifier-manager then never becomes Ready.

Part of [485](https://github.com/projectsveltos/classifier/issues/485)