### PR TITLE
[CI] Push helm charts to OCI registry and prepare sign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release Charts
+permissions: {}
 
 on:
   push:
@@ -7,19 +8,79 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write # to push chart release and create a release (helm/chart-releaser-action)
+      packages: write # needed for ghcr access
+      id-token: write # needed for keyless signing
+
+    runs-on: ubuntu-24.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
+      - name: Checkout Code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
 
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      - name: GPG configuration
+        if: false # skip for now until a GPG key is available
+        run: |-
+          echo "$GPG_KEY" > "$GPG_KEY_PATH"
+          mkdir -p "$HOME/.gnupg"
+          chmod 0700 "$HOME/.gnupg"
+          echo "use-agent" > "$HOME/.gnupg/gpg.conf"
+          echo "pinentry-mode loopback" >> "$HOME/.gnupg/gpg.conf"
+          echo "allow-loopback-pinentry" > "$HOME/.gnupg/gpg-agent.conf"
+          echo "max-cache-ttl 86400" >> "$HOME/.gnupg/gpg-agent.conf"
+          echo "default-cache-ttl 86400" >> "$HOME/.gnupg/gpg-agent.conf"
+          gpgconf --kill gpg-agent
+          gpgconf --launch gpg-agent
+          gpg --batch --yes --passphrase-fd 0 --import "$GPG_KEY_PATH" <<< "$GPG_PASSPHRASE"
+
+          mkdir "${{ runner.temp }}/.gnupg/"
+          gpg --batch --yes --export "$GPG_KEY_ID" >~/.gnupg/pubring.gpg
+          gpg --batch --yes --passphrase-fd 0 --export-secret-keys "$GPG_KEY_ID" >~/.gnupg/secring.gpg <<< "$GPG_PASSPHRASE"
+          cat > "$GPG_PASSPHRASE_FILE" <<< "$GPG_PASSPHRASE"
+        env:
+          GPG_KEY_ID: "${{ vars.GPG_KEY_ID }}"
+          GPG_KEY: "${{ secrets.GPG_PRIVATE_KEY }}"
+          GPG_PASSPHRASE: "${{ secrets.GPG_PASSPHRASE }}"
+          GPG_PASSPHRASE_FILE: "${{ runner.temp }}/gpg-passphrase"
+          GPG_KEY_PATH: "${{ runner.temp }}/private.key"
+
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
+        with:
+          skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_GENERATE_RELEASE_NOTES: true
+          # CR_SIGN: true
+          # CR_KEY: "${{ vars.GPG_KEY_NAME }}"
+          # CR_KEYRING: "~/.gnupg/secring.gpg"
+          # CR_PASSPHRASE_FILE: "${{ runner.temp }}/gpg-passphrase"
+
+      # see https://github.com/helm/chart-releaser/issues/183
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push charts to GHCR
+        run: |
+          shopt -s nullglob
+          for pkg in .cr-release-packages/*.tgz; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/helm-charts"
+          done


### PR DESCRIPTION
* Helm supports [OCI registries](https://helm.sh/docs/topics/registries/) while the official helm releaser not.
* Prepare signing for helm charts, which still based on [GPG](https://helm.sh/docs/topics/provenance/#overview).

Copied from https://github.com/grafana-community/helm-charts/blob/main/.github/workflows/release.yaml