### PR TITLE
[CI] Add pipeline check for PR title

### DIFF
--- a/.github/linters/ct.yaml
+++ b/.github/linters/ct.yaml
@@ -4,10 +4,6 @@ additional-commands:
   - helm unittest --strict --file 'tests/**/*.yaml' {{ .Path }}
 chart-dirs:
   - charts
-chart-repos:
-  - minio=https://charts.min.io/
-  - grafana=https://grafana.github.io/helm-charts
-  - prometheus-community=https://prometheus-community.github.io/helm-charts
 github-groups: true
 helm-extra-args: --timeout 600s
 remote: origin

--- a/.github/linters/ct.yaml
+++ b/.github/linters/ct.yaml
@@ -1,0 +1,16 @@
+# See https://github.com/helm/chart-testing#configuration
+additional-commands:
+  - sh -ec "if [ -f '{{ .Path }}/ci/lint.sh' ]; then bash '{{ .Path }}/ci/lint.sh'; fi"
+  - helm unittest --strict --file 'tests/**/*.yaml' {{ .Path }}
+chart-dirs:
+  - charts
+chart-repos:
+  - minio=https://charts.min.io/
+  - grafana=https://grafana.github.io/helm-charts
+  - prometheus-community=https://prometheus-community.github.io/helm-charts
+github-groups: true
+helm-extra-args: --timeout 600s
+remote: origin
+target-branch: main
+use-helmignore: true
+validate-maintainers: false

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,78 @@
+name: Pull Request
+permissions: {}
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: ["opened", "reopened", "synchronize", "edited"]
+
+jobs:
+  check-title:
+    name: Check Title
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          # renovate: github=helm/helm
+          version: v4.2.3
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.13"
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
+        with:
+          # renovate: github=helm/chart-testing
+          version: v3.14.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed="$(ct list-changed --config .github/linters/ct.yaml)"
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "changed_list=\"${changed//$'\n'/ }\"" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate PR Title format
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          CHANGED_LIST="${CHANGED_LIST//\"/}"
+
+          # Derive chart name from the changed path and validate it.
+          if [[ "$CHANGED_LIST" == */* ]]; then
+            CHART_NAME="${CHANGED_LIST##*/}"
+          else
+            echo "Error: Unexpected chart identifier '$CHANGED_LIST'. Expected a path containing '/'." >&2
+            exit 1
+          fi
+
+          if [[ -z "$CHART_NAME" ]]; then
+            echo "Error: Derived chart name is empty. Original value: '$CHANGED_LIST'." >&2
+            exit 1
+          fi
+
+          # Optional sanity check: ensure chart name contains only expected characters.
+          if ! [[ "$CHART_NAME" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+            echo "Error: Derived chart name '$CHART_NAME' contains unexpected characters." >&2
+            exit 1
+          fi
+
+          if [[ "$PR_TITLE" != "[${CHART_NAME}] "* ]]; then
+            echo "PR title must start with '[${CHART_NAME}] '." >&2
+            exit 1
+          fi
+        env:
+          CHANGED_LIST: ${{ steps.list-changed.outputs.changed_list }}
+          PR_TITLE: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
This PR adds an lint check for PRs to ensure that only one chart is modified per PR and enforced the PR title in style `[chart-name] title`.

Copied from https://github.com/grafana-community/helm-charts/blob/main/.github/workflows/pull-request.yaml