### PR TITLE
[ADMIN] Add renovate.json for dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigestsToSemver"
+  ],
+  "schedule": [
+    "* * * * 5"
+  ],
+  "suppressNotifications": ["prEditedNotification"],
+  "dependencyDashboardApproval": false,
+  "automerge": true,
+  "platformAutomerge": true,
+  "labels": ["dependencies"],
+  "rebaseWhen": "behind-base-branch",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/).+\\.(py|yaml)$/",
+        "/(^|/)Makefile$/"
+      ],
+      "matchStrings": [
+        "[\\t ]*(?:#|//) ?renovate: (?<datasource>git-refs)=(?<depName>\\S+)(?: branch=(?<currentValue>\\S+))?[\\t ]*\\r?\\n.+?[:=][\\t ]*[\"']?(?<currentDigest>[a-f0-9]+)[\"']?",
+        "[\\t ]*(?:#|//) ?renovate: (?<datasource>[^=]+)=(?<depName>\\S+)(?: registry=(?<registryUrl>\\S+))?(?: versioning=(?<versioning>\\S+))?[\\t ]*\\r?\\n.+?[:=][\\t ]*[\"']?(?<currentValue>[^@\\s\"'=]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?[\"']?"
+      ],
+      "currentValueTemplate": "{{#if currentValue}}{{{currentValue}}}{{else if (equals datasource 'git-refs')}}main{{/if}}",
+      "datasourceTemplate": "{{#if (equals datasource 'github')}}github-tags{{else}}{{{datasource}}}{{/if}}",
+      "versioningTemplate": "{{#if (equals datasource 'docker')}}docker{{else if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/).+\\.yaml$/"
+      ],
+      "matchStrings": [
+        "[\\t ]*image:\\s+registry:\\s*[\\\"']?(?<registry>\\S+\\.\\S+?)[\\\"']?[\\t ]*\\r?\\n[\\t ]*(?:repository|name):\\s*[\\\"']?(?<repository>.*?)[\\\"']?[\\t ]*\\r?\\n[\\t ]*tag:\\s*[\\\"']?(?<currentValue>[\\w+\\.\\-]*)(?:@(?<currentDigest>sha256:[a-f0-9]+))?[\\\"']?"
+      ],
+      "depNameTemplate": "{{{ registry }}}/{{{ repository }}}",
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/).+\\.yaml$/"
+      ],
+      "matchStrings": [
+        "[\\t ]*image:\\s+[\\\"']?(?<registry>\\S+\\.\\S+?)\\/(?<repository>.*?):(?<currentValue>[\\w+\\.\\-]*)(?:@(?<currentDigest>sha256:[a-f0-9]+))?[\\\"']?"
+      ],
+      "depNameTemplate": "{{{ registry }}}/{{{ repository }}}",
+      "datasourceTemplate": "docker"
+    }
+  ],
+  "packageRules": [
+    {
+      "enabled": false,
+      "matchPackageNames": [
+        "*"
+      ]
+    },
+    {
+      "enabled": true,
+      "matchFileNames": [
+        ".github/workflows/**"
+      ],
+      "commitMessagePrefix": "[CI] ",
+      "groupName": "github-workflow dependency updates",
+      "matchPackageNames": [
+        "*"
+      ],
+      "schedule": null,
+      "labels": ["dependencies", "dependencies/auto-merge"]
+    },
+    {
+      "enabled": true,
+      "matchFileNames": [
+        "Makefile"
+      ],
+      "commitMessagePrefix": "[CI] ",
+      "groupName": "Makefile dependency updates",
+      "matchPackageNames": [
+        "*"
+      ],
+      "schedule": null,
+      "labels": ["dependencies", "dependencies/auto-merge"]
+    },
+    {
+      "enabled": true,
+      "matchFileNames": [
+        "charts/**"
+      ],
+      "commitMessagePrefix": "[{{ lookup (split packageFileDir '/') 1 }}] ",
+      "groupName": "{{ lookup (split packageFileDir '/') 1 }} dependency non-major updates",
+      "separateMajorMinor": true,
+      "postUpdateOptions": [
+        "helmUpdateSubChartArchives"
+      ],
+      "schedule": null,
+      "labels": ["dependencies", "dependencies/auto-merge"],
+      "major": {
+        "description": "Exclude major version bumps from auto merge.",
+        "labels": ["dependencies"],
+        "groupName": "{{ lookup (split packageFileDir '/') 1 }} dependency major updates"
+      },
+      "matchPackageNames": [
+        "*"
+      ],
+      "bumpVersions": [
+        {
+          "name": "Updating Chart version",
+          "filePatterns": ["/^({{#each (distinct (lookupArray upgrades \"packageFileDir\"))}}{{{lookup (split . \"/\") 0}}}/{{{lookup (split . \"/\") 1}}}{{#unless @last}}|{{/unless}}{{/each}})/Chart\\.ya?ml$/"],
+          "matchStrings": ["(?:^|\\n)version:\\s\"?(?<version>\\d+\\.\\d+\\.\\d+)\"?(?:$|\\n)"],
+          "bumpType": "{{#if (or isPinDigest isPatch)}}patch{{else}}minor{{/if}}"
+        }
+      ]
+    },
+    {
+      "matchDatasources": [
+        "git-refs"
+      ],
+      "schedule": [
+        "* 14-17 * * 2,5"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Automates CI and chart dependencies.

Based on https://github.com/grafana-community/helm-charts/blob/main/renovate.json

Requires to enable renovate app on this repository.