### PR TITLE
[CI] Add CI pipeline for basic chart validation

### DIFF
--- a/.github/linters/.codespellrc
+++ b/.github/linters/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+# AKS = Azure Kubernetes Service (valid acronym)
+# notin = Kubernetes matchExpression operator "NotIn"
+ignore-words-list = aks,notin

--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -1,0 +1,14 @@
+MD013:
+  line_length: 600
+MD060:
+  enabled: false
+MD022:
+  enabled: false
+MD031:
+  enabled: false
+MD032:
+  enabled: false
+MD033:
+  enabled: false
+MD034:
+  enabled: false

--- a/.github/linters/.schema.yaml
+++ b/.github/linters/.schema.yaml
@@ -1,0 +1,24 @@
+# $schema=https://github.com/losisin/helm-values-schema-json/raw/refs/heads/main/config.schema.json
+
+values:
+  - values.yaml
+
+draft: 7
+indent: 4
+output: values.schema.json
+
+bundle: true
+bundleRoot: ""
+bundleWithoutID: true
+
+k8sSchemaURL: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/{{ .K8sSchemaVersion }}/
+k8sSchemaVersion: "v1.36.1"
+
+useHelmDocs: true
+
+noAdditionalProperties: false
+noDefaultGlobal: false
+
+schemaRoot:
+  id: https://github.com/grafana-community/helm-charts
+  additionalProperties: true

--- a/.github/linters/.schema.yaml
+++ b/.github/linters/.schema.yaml
@@ -20,5 +20,5 @@ noAdditionalProperties: false
 noDefaultGlobal: false
 
 schemaRoot:
-  id: https://github.com/grafana-community/helm-charts
+  id: https://github.com/projectsveltos/helm-charts
   additionalProperties: true

--- a/.github/linters/.textlintrc
+++ b/.github/linters/.textlintrc
@@ -1,0 +1,8 @@
+{
+  "filters": {
+    "comments": true
+  },
+  "rules": {
+    "terminology": true
+  }
+}

--- a/.github/linters/ct.yaml
+++ b/.github/linters/ct.yaml
@@ -4,10 +4,6 @@ additional-commands:
   - helm unittest --strict --file 'tests/**/*.yaml' {{ .Path }}
 chart-dirs:
   - charts
-chart-repos:
-  - minio=https://charts.min.io/
-  - grafana=https://grafana.github.io/helm-charts
-  - prometheus-community=https://prometheus-community.github.io/helm-charts
 github-groups: true
 helm-extra-args: --timeout 600s
 remote: origin

--- a/.github/linters/ct.yaml
+++ b/.github/linters/ct.yaml
@@ -1,0 +1,16 @@
+# See https://github.com/helm/chart-testing#configuration
+additional-commands:
+  - sh -ec "if [ -f '{{ .Path }}/ci/lint.sh' ]; then bash '{{ .Path }}/ci/lint.sh'; fi"
+  - helm unittest --strict --file 'tests/**/*.yaml' {{ .Path }}
+chart-dirs:
+  - charts
+chart-repos:
+  - minio=https://charts.min.io/
+  - grafana=https://grafana.github.io/helm-charts
+  - prometheus-community=https://prometheus-community.github.io/helm-charts
+github-groups: true
+helm-extra-args: --timeout 600s
+remote: origin
+target-branch: main
+use-helmignore: true
+validate-maintainers: false

--- a/.github/linters/kind.yaml
+++ b/.github/linters/kind.yaml
@@ -1,0 +1,32 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      #language=yaml
+      - |
+        apiVersion: kubelet.config.k8s.io/v1beta1
+        kind: KubeletConfiguration
+        failSwapOn: false
+        memorySwap:
+          swapBehavior: LimitedSwap
+
+  - role: worker
+    kubeadmConfigPatches:
+      #language=yaml
+      - |
+        apiVersion: kubelet.config.k8s.io/v1beta1
+        kind: KubeletConfiguration
+        failSwapOn: false
+        memorySwap:
+          swapBehavior: LimitedSwap
+
+  - role: worker
+    kubeadmConfigPatches:
+      #language=yaml
+      - |
+        apiVersion: kubelet.config.k8s.io/v1beta1
+        kind: KubeletConfiguration
+        failSwapOn: false
+        memorySwap:
+          swapBehavior: LimitedSwap

--- a/.github/linters/zizmor.yml
+++ b/.github/linters/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  cache-poisoning:
+    disable: true
+  secrets-outside-env:
+    disable: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,368 @@
+name: CI
+permissions: {}
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  chart-testing:
+    name: Chart Testing
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      changed: ${{ steps.list-changed.outputs.changed }}
+      changed_list: ${{ steps.list-changed.outputs.changed_list }}
+      values_files_json: ${{ steps.test-matrix.outputs.values_files_json }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          # renovate: github=helm/helm
+          version: v4.2.3
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.14"
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
+        with:
+          # renovate: github=helm/chart-testing
+          version: v3.14.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        # language=bash
+        run: |
+          changed="$(ct list-changed --config .github/linters/ct.yaml)"
+          if [[ -n "$changed" ]]; then
+            num_changed="$(printf '%s\n' "$changed" | wc -l | tr -d ' ')"
+            if [ "$num_changed" -gt 1 ]; then
+              echo "More than one chart changed (count=$num_changed). Failing."
+              printf '%s\n' "$changed"
+              exit 1
+            fi
+
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "changed_list=${changed//$'\n'/ }" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: install helm unittest plugin
+        if: steps.list-changed.outputs.changed == 'true'
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version "${VERSION}" --verify=false
+        env:
+          # renovate: github=helm-unittest/helm-unittest
+          VERSION: 1.1.1
+
+      - name: install helm values-schema plugin
+        if: steps.list-changed.outputs.changed == 'true'
+        run: helm plugin install https://github.com/losisin/helm-values-schema-json.git --version "${VERSION}" --verify=false
+        env:
+          # renovate: github=losisin/helm-values-schema-json
+          VERSION: 2.5.0
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config .github/linters/ct.yaml
+
+      - name: Generate test matrix
+        if: steps.list-changed.outputs.changed == 'true'
+        id: test-matrix
+        env:
+          CHANGED_LIST: ${{ steps.list-changed.outputs.changed_list }}
+        #language=bash
+        run: |
+          set -euo pipefail
+
+          read -r -a charts <<< "$CHANGED_LIST"
+          values_files_json="[\"${charts[0]}/values.yaml\"]"
+          if [[ -d "${charts[0]}/ci" ]]; then
+            ci_values_files_json="$(
+              find "${charts[0]}/ci" -maxdepth 1 -type f -name '*-values.yaml' -print \
+                | sort \
+                | jq --raw-input --slurp --compact-output 'split("\n") | map(select(length > 0))'
+            )"
+            if [[ "$ci_values_files_json" != "[]" ]]; then
+              values_files_json="$ci_values_files_json"
+            fi
+          fi
+
+          values_files_json="$(
+            jq --compact-output 'map({valuefile: ., name: sub("^charts/[^/]+/"; "")})' <<< "$values_files_json"
+          )"
+
+          echo "values_files_json=$values_files_json" >> "$GITHUB_OUTPUT"
+
+
+  integration-tests:
+    name: Integration Tests (${{ matrix.name }})
+    timeout-minutes: 15
+    needs: chart-testing
+    runs-on: ubuntu-latest
+    # disable integration tests for now
+    if: needs.chart-testing.outputs.changed == 'true' && false
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.chart-testing.outputs.values_files_json) }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Checkout Target of PR
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: target
+          ref: ${{ github.event.pull_request.base.ref }}
+          persist-credentials: false
+
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          # renovate: github=helm/helm
+          version: v4.2.3
+
+      - name: install helm diff plugin
+        run: helm plugin install https://github.com/databus23/helm-diff --version 3.15.4 --verify=false
+
+      - name: Create kind cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          config: .github/linters/kind.yaml
+          ignore_failed_clean: 'true'
+
+      - name: Apply Gateway API CRDs
+        run: kubectl apply -k https://github.com/kubernetes-sigs/gateway-api/config/crd
+
+      - name: Apply Prometheus Operator CRDs
+        run: helm install prometheus-operator-crds oci://ghcr.io/prometheus-community/charts/prometheus-operator-crds
+
+      - name: Apply KEDA CRDs
+        run: kubectl apply --server-side -f "https://github.com/kedacore/keda/releases/download/v${KEDA_VERSION}/keda-${KEDA_VERSION}-crds.yaml"
+        env:
+          #renovate: github=kedacore/keda
+          KEDA_VERSION: 2.20.1
+
+      - name: Provision integration test prerequisites
+        if: needs.chart-testing.outputs.changed == 'true'
+        env:
+          CHANGED_LIST: ${{ needs.chart-testing.outputs.changed_list }}
+        run: |
+          for chart in $CHANGED_LIST; do
+            if [ -f "$chart/ci/integration/it-prerequisites.yaml" ]; then
+              echo "Provisioning prerequisites for $chart"
+              kubectl apply -f "$chart/ci/integration/it-prerequisites.yaml"
+            fi
+          done
+          kubectl wait pod -l ci-managed=true -A \
+            --for=condition=ready --timeout=300s 2>/dev/null || true
+
+      - name: Setup chart dependencies
+        id: setup
+        env:
+          value_file: "${{ matrix.valuefile }}"
+        # language=bash
+        run: |
+          set -euo pipefail
+          IFS=$'\n\t'
+
+          echo "Running diff for value file: $value_file"
+          # extract chart name from path like charts/<chart>/ci/<file>
+          # dirname twice: charts/<chart>/ci -> charts/<chart>, basename -> <chart>
+          chart="$(basename "$(dirname "$(dirname "$value_file")")")"
+
+          helm dependency update "./target/charts/$chart"
+          helm dependency update "./charts/$chart"
+
+          echo chart="$chart" >> "$GITHUB_OUTPUT"
+
+      - name: Run helm install from main branch
+        id: install
+        env:
+          chart: "${{ steps.setup.outputs.chart }}"
+          value_file: "${{ matrix.valuefile }}"
+        # language=bash
+        run: |
+          # install current target chart into cluster so helm diff has a baseline
+          helm upgrade -i "$chart" "./target/charts/$chart" \
+            --create-namespace \
+            --namespace "$chart" \
+            --wait \
+            --values "$value_file"
+
+      - name: Debug failed installation
+        if: failure() && steps.install.outcome == 'failure'
+        timeout-minutes: 6
+        env:
+          chart: "${{ steps.setup.outputs.chart }}"
+        # language=bash
+        run: |
+          echo "::group::kubectl describe nodes"
+          kubectl describe nodes
+          echo "::endgroup::"
+          echo "::group::kubectl get ns"
+          kubectl get ns --show-labels
+          echo "::endgroup::"
+          echo "::group::kubectl get events"
+          kubectl events --namespace "$chart"
+          echo "::endgroup::"
+          echo "::group::kubectl get deploy,ds,sts"
+          kubectl get deploy,ds,sts --namespace "$chart"
+          echo "::endgroup::"
+          echo "::group::kubectl get pods"
+          kubectl get pods --namespace "$chart" -o wide
+          echo "::endgroup::"
+          for pod in $(kubectl get pods --namespace "$chart" -o jsonpath='{.items[*].metadata.name}'); do
+            echo "::group::pods/$pod"
+            kubectl describe --namespace "$chart" "pods/$pod" || true
+            echo "--------------------------------"
+            kubectl logs --namespace "$chart" "$pod" || true
+            echo "--------------------------------"
+            kubectl logs --namespace "$chart" "$pod" -p || true
+            echo "::endgroup::"
+          done
+
+      - name: Run helm diff
+        env:
+          chart: "${{ steps.setup.outputs.chart }}"
+          value_file: "${{ matrix.valuefile }}"
+        #language=bash
+        run: |
+          set -euo pipefail
+          IFS=$'\n\t'
+
+          {
+            printf '```diff\n'
+            helm diff upgrade "$chart" "./charts/$chart" \
+              --namespace "$chart" \
+              --suppress=CustomResourceDefinition \
+              --normalize-manifests \
+              --reset-values \
+              --no-color \
+              -C 5 \
+              --suppress-output-line-regex="helm.sh/chart:" \
+              --suppress-output-line-regex="chart:" \
+              --suppress-output-line-regex="app.kubernetes.io/version:" \
+              --values "$value_file" | tee /dev/stderr
+            printf '\n```'
+          } > "$GITHUB_STEP_SUMMARY"
+
+
+      - name: Run helm install from PR branch
+        timeout-minutes: 6
+        id: upgrade
+        env:
+          chart: "${{ steps.setup.outputs.chart }}"
+          value_file: "${{ matrix.valuefile }}"
+        # language=bash
+        run: |
+          helm upgrade -i "$chart" "./charts/$chart" \
+            --create-namespace \
+            --namespace "$chart" \
+            --wait \
+            --values "$value_file"
+
+      - name: Debug failed upgrade
+        if: failure() && steps.upgrade.outcome == 'failure'
+        env:
+          chart: "${{ steps.setup.outputs.chart }}"
+        # language=bash
+        run: |
+          echo "::group::kubectl describe nodes"
+          kubectl describe nodes
+          echo "::endgroup::"
+          echo "::group::kubectl get ns"
+          kubectl get ns --show-labels
+          echo "::endgroup::"
+          echo "::group::kubectl get events"
+          kubectl events --namespace "$chart"
+          echo "::endgroup::"
+          echo "::group::kubectl get deploy,ds,sts"
+          kubectl get deploy,ds,sts --namespace "$chart"
+          echo "::endgroup::"
+          echo "::group::kubectl get pods"
+          kubectl get pods --namespace "$chart" -o wide
+          echo "::endgroup::"
+          for pod in $(kubectl get pods --namespace "$chart" -o jsonpath='{.items[*].metadata.name}'); do
+            echo "::group::pods/$pod"
+            kubectl describe --namespace "$chart" "pods/$pod" || true
+            echo "--------------------------------"
+            kubectl logs --namespace "$chart" "$pod" || true
+            echo "--------------------------------"
+            kubectl logs --namespace "$chart" "$pod" -p || true
+            echo "::endgroup::"
+          done
+
+      - name: helm test
+        timeout-minutes: 6
+        env:
+          chart: "${{ steps.setup.outputs.chart }}"
+          value_file: "${{ matrix.valuefile }}"
+        # language=bash
+        run: |
+          helm test "$chart" --namespace "$chart" --logs
+
+
+  fail:
+    if: "${{ cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}"
+    needs:
+      - chart-testing
+      - integration-tests
+    runs-on: "ubuntu-24.04"
+    steps:
+      - name: "verify checks passed"
+        run: |
+          echo "Some checks have failed!"
+          exit 1
+
+  super-linter:
+    name: Super Linter
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          fetch-tags: 'false'
+
+      - name: Lint Code Base
+        uses: super-linter/super-linter/slim@4ce20838b8ab83717e78138c5b3a1407148e0918 # v8.7.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MULTI_STATUS: false
+          LINTER_RULES_PATH: .github/linters
+          GITHUB_ACTIONS_ZIZMOR_CONFIG_FILE: ../../../github/workspace/.github/linters/zizmor.yml
+          ENABLE_GITHUB_ACTIONS_STEP_SUMMARY: true
+          ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT: false
+          SAVE_SUPER_LINTER_SUMMARY: true
+          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_BASH: true
+          VALIDATE_BASH_EXEC: true
+          VALIDATE_EDITORCONFIG: true
+          VALIDATE_ENV: true
+          VALIDATE_GITHUB_ACTIONS: true
+          VALIDATE_GITHUB_ACTIONS_ZIZMOR: true
+          VALIDATE_GITLEAKS: true
+          VALIDATE_HTML: true
+          VALIDATE_JSON: true
+          VALIDATE_NATURAL_LANGUAGE: true
+          # VALIDATE_MARKDOWN: true - disable to for now.
+          VALIDATE_RENOVATE: true
+          VALIDATE_SHELL_SHFMT: true
+          VALIDATE_SPELL_CODESPELL: true
+          # VALIDATE_XML: true
+          # VALIDATE_YAML: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,12 +148,6 @@ jobs:
       - name: Apply Prometheus Operator CRDs
         run: helm install prometheus-operator-crds oci://ghcr.io/prometheus-community/charts/prometheus-operator-crds
 
-      - name: Apply KEDA CRDs
-        run: kubectl apply --server-side -f "https://github.com/kedacore/keda/releases/download/v${KEDA_VERSION}/keda-${KEDA_VERSION}-crds.yaml"
-        env:
-          #renovate: github=kedacore/keda
-          KEDA_VERSION: 2.20.1
-
       - name: Provision integration test prerequisites
         if: needs.chart-testing.outputs.changed == 'true'
         env:


### PR DESCRIPTION
Basicly running the chart testing tool which validates a chart version bump on each contributes.

Additioally, running [super-linter](https://github.com/super-linter/super-linter) which invokes [zizmor](https://github.com/zizmorcore/zizmor) for github actions hardenings.

Integration tests are disabled for now.

Ref: https://github.com/grafana-community/helm-charts/blob/main/.github/workflows/ci.yaml